### PR TITLE
feat: add auto file open 

### DIFF
--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/FileChangeService.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/FileChangeService.kt
@@ -2,6 +2,7 @@ package com.github.x0x0b.codexlauncher
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.util.messages.MessageBusConnection
 import com.intellij.openapi.vfs.VirtualFileManager
@@ -12,6 +13,7 @@ import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.github.x0x0b.codexlauncher.settings.CodexLauncherSettings
 import java.nio.file.*
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
@@ -140,6 +142,11 @@ class FileChangeService(private val project: Project) : Disposable {
     }
 
     private fun openFileInEditor(file: com.intellij.openapi.vfs.VirtualFile) {
+        val settings = service<CodexLauncherSettings>()
+        if (!settings.state.openFileOnChange) {
+            return
+        }
+        
         ApplicationManager.getApplication().invokeLater {
             if (project.isDisposed) return@invokeLater
             FileEditorManager.getInstance(project).openFile(file, true)

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/FileChangeService.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/FileChangeService.kt
@@ -11,12 +11,24 @@ import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.vfs.LocalFileSystem
+import java.nio.file.*
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
 
 @Service(Service.Level.PROJECT)
 class FileChangeService(private val project: Project) : Disposable {
-    
+
     private val connection: MessageBusConnection = project.messageBus.connect(this)
-    
+    private var watchService: WatchService? = null
+    private val executor = Executors.newSingleThreadExecutor(ThreadFactory { thread ->
+        Thread(thread).apply {
+            isDaemon = true
+            name = "FileChangeWatcher-${project.name}"
+        }
+    })
+    private var isWatching = true
+
     init {
         connection.subscribe(VirtualFileManager.VFS_CHANGES, object : BulkFileListener {
             override fun after(events: List<VFileEvent>) {
@@ -28,6 +40,7 @@ class FileChangeService(private val project: Project) : Disposable {
                                 openFileInEditor(file)
                             }
                         }
+
                         is VFileCreateEvent -> {
                             event.file?.let { file ->
                                 if (isProjectFile(file.path)) {
@@ -39,21 +52,107 @@ class FileChangeService(private val project: Project) : Disposable {
                 }
             }
         })
+
+        // 直接ファイルシステム監視を開始
+        startNativeFileWatcher()
     }
-    
+
+    private fun startNativeFileWatcher() {
+        val projectPath = project.basePath ?: return
+
+        try {
+            watchService = FileSystems.getDefault().newWatchService()
+            val projectDir = Paths.get(projectPath)
+
+            // プロジェクトディレクトリを再帰的に監視
+            registerDirectoryTree(projectDir)
+
+            executor.submit {
+                try {
+                    while (isWatching && !project.isDisposed) {
+                        val key = watchService?.poll(1, java.util.concurrent.TimeUnit.SECONDS)
+                        if (key != null) {
+                            for (event in key.pollEvents()) {
+                                if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE ||
+                                    event.kind() == StandardWatchEventKinds.ENTRY_MODIFY
+                                ) {
+                                    val fileName = event.context() as Path
+                                    val fullPath = (key.watchable() as Path).resolve(fileName)
+
+                                    // ディレクトリの場合は新しく監視に追加
+                                    if (Files.isDirectory(fullPath)) {
+                                        registerDirectoryTree(fullPath)
+                                    } else {
+                                        handleFileChange(fullPath.toString())
+                                    }
+                                }
+                            }
+                            key.reset()
+                        }
+                    }
+                } catch (e: Exception) {
+                    // 監視終了時の例外は無視
+                }
+            }
+        } catch (e: Exception) {
+            // WatchService初期化失敗時はフォールバック
+        }
+    }
+
+    private fun registerDirectoryTree(start: Path) {
+        try {
+            Files.walk(start).use { paths ->
+                paths.filter { Files.isDirectory(it) }
+                    .filter { !it.fileName.toString().startsWith(".") } // 隠しディレクトリを除外
+                    .forEach { dir ->
+                        try {
+                            dir.register(
+                                watchService,
+                                StandardWatchEventKinds.ENTRY_CREATE,
+                                StandardWatchEventKinds.ENTRY_MODIFY
+                            )
+                        } catch (e: Exception) {
+                            // 個別のディレクトリ登録失敗は無視
+                        }
+                    }
+            }
+        } catch (e: Exception) {
+            // 登録失敗時は無視
+        }
+    }
+
+    private fun handleFileChange(filePath: String) {
+        if (isProjectFile(filePath)) {
+            ApplicationManager.getApplication().invokeLater {
+                if (!project.isDisposed) {
+                    // ファイルをVirtualFileSystemで取得してエディタで開く
+                    LocalFileSystem.getInstance().findFileByPath(filePath)?.let { virtualFile ->
+                        openFileInEditor(virtualFile)
+                    }
+                }
+            }
+        }
+    }
+
     private fun isProjectFile(filePath: String): Boolean {
         val projectBasePath = project.basePath ?: return false
         return filePath.startsWith(projectBasePath) && !filePath.endsWith("/")
     }
-    
+
     private fun openFileInEditor(file: com.intellij.openapi.vfs.VirtualFile) {
         ApplicationManager.getApplication().invokeLater {
             if (project.isDisposed) return@invokeLater
             FileEditorManager.getInstance(project).openFile(file, true)
         }
     }
-    
+
     override fun dispose() {
-        // Connection is disposed automatically
+        isWatching = false
+        try {
+            watchService?.close()
+        } catch (e: Exception) {
+            // 無視
+        }
+        executor.shutdown()
     }
 }

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/FileChangeService.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/FileChangeService.kt
@@ -1,0 +1,59 @@
+package com.github.x0x0b.codexlauncher
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.util.messages.MessageBusConnection
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.application.ApplicationManager
+
+@Service(Service.Level.PROJECT)
+class FileChangeService(private val project: Project) : Disposable {
+    
+    private val connection: MessageBusConnection = project.messageBus.connect(this)
+    
+    init {
+        connection.subscribe(VirtualFileManager.VFS_CHANGES, object : BulkFileListener {
+            override fun after(events: List<VFileEvent>) {
+                for (event in events) {
+                    when (event) {
+                        is VFileContentChangeEvent -> {
+                            val file = event.file
+                            if (isProjectFile(file.path)) {
+                                openFileInEditor(file)
+                            }
+                        }
+                        is VFileCreateEvent -> {
+                            event.file?.let { file ->
+                                if (isProjectFile(file.path)) {
+                                    openFileInEditor(file)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+    
+    private fun isProjectFile(filePath: String): Boolean {
+        val projectBasePath = project.basePath ?: return false
+        return filePath.startsWith(projectBasePath) && !filePath.endsWith("/")
+    }
+    
+    private fun openFileInEditor(file: com.intellij.openapi.vfs.VirtualFile) {
+        ApplicationManager.getApplication().invokeLater {
+            if (project.isDisposed) return@invokeLater
+            FileEditorManager.getInstance(project).openFile(file, true)
+        }
+    }
+    
+    override fun dispose() {
+        // Connection is disposed automatically
+    }
+}

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/FileChangeStartupActivity.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/FileChangeStartupActivity.kt
@@ -1,0 +1,11 @@
+package com.github.x0x0b.codexlauncher
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
+
+class FileChangeStartupActivity : StartupActivity {
+    override fun runActivity(project: Project) {
+        // サービスを明示的に初期化
+        project.getService(FileChangeService::class.java)
+    }
+}

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/LaunchCodexAction.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/LaunchCodexAction.kt
@@ -1,9 +1,7 @@
 package com.github.x0x0b.codexlauncher
 
 import com.github.x0x0b.codexlauncher.settings.CodexLauncherSettings
-import com.intellij.notification.Notification
 import com.intellij.notification.NotificationType
-import com.intellij.notification.Notifications
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.components.service

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.ui.ComboBox
+import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBRadioButton
 import com.intellij.ui.components.JBTextField
 import com.intellij.ui.dsl.builder.panel
@@ -19,6 +20,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
     private lateinit var modeFullAutoRadio: JBRadioButton
     private lateinit var modelCombo: JComboBox<Model>
     private lateinit var customModelField: JBTextField
+    private lateinit var openFileOnChangeCheckbox: JBCheckBox
 
     private val settings by lazy { service<CodexLauncherSettings>() }
 
@@ -40,6 +42,9 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         customModelField = JBTextField()
         customModelField.emptyText.text = "e.g. gpt-5"
         customModelField.isEnabled = false
+        
+        // File opening control
+        openFileOnChangeCheckbox = JBCheckBox("Open files automatically when changed")
         // Block invalid characters at input time
         (customModelField.document as? AbstractDocument)?.documentFilter = object : DocumentFilter() {
 
@@ -88,6 +93,11 @@ class CodexLauncherConfigurable : SearchableConfigurable {
                         .applyToComponent { columns = 50 }
                 }
             }
+            group("File Handling") {
+                row {
+                    cell(openFileOnChangeCheckbox)
+                }
+            }
         }
 
         return root
@@ -97,7 +107,8 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         val s = settings.state
         return getMode() != s.mode ||
                 getModel() != s.model ||
-                getCustomModel() != s.customModel
+                getCustomModel() != s.customModel ||
+                getOpenFileOnChange() != s.openFileOnChange
     }
 
     override fun apply() {
@@ -111,6 +122,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         s.mode = getMode()
         s.model = getModel()
         s.customModel = getCustomModel()
+        s.openFileOnChange = getOpenFileOnChange()
     }
 
     override fun reset() {
@@ -120,6 +132,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         modelCombo.selectedItem = s.model
         customModelField.text = s.customModel
         customModelField.isEnabled = (s.model == Model.CUSTOM)
+        openFileOnChangeCheckbox.isSelected = s.openFileOnChange
     }
 
     fun getMode(): Mode {
@@ -139,5 +152,9 @@ class CodexLauncherConfigurable : SearchableConfigurable {
 
     private fun getCustomModel(): String {
         return customModelField.text?.trim() ?: ""
+    }
+    
+    private fun getOpenFileOnChange(): Boolean {
+        return openFileOnChangeCheckbox.isSelected
     }
 }

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherSettings.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherSettings.kt
@@ -13,7 +13,8 @@ class CodexLauncherSettings : PersistentStateComponent<CodexLauncherSettings.Sta
     data class State(
         var mode: Mode = Mode.DEFAULT,
         var model: Model = Model.DEFAULT,
-        var customModel: String = ""
+        var customModel: String = "",
+        var openFileOnChange: Boolean = true
     )
 
     private var state = State()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -50,6 +50,7 @@
   <extensions defaultExtensionNs="com.intellij">
     <notificationGroup id="CodexLauncher" displayType="BALLOON" isLogByDefault="true"/>
     <applicationConfigurable instance="com.github.x0x0b.codexlauncher.settings.CodexLauncherConfigurable" id="com.github.x0x0b.codexlauncher.settings" displayName="Codex Launcher"/>
+    <postStartupActivity implementation="com.github.x0x0b.codexlauncher.FileChangeStartupActivity"/>
   </extensions>
 
   <actions>


### PR DESCRIPTION
This pull request introduces a new file change monitoring feature to the project, allowing automatic opening of files in the editor when they are modified or created. The feature is configurable via a new checkbox in the settings, giving users control over whether files are opened automatically on change. The implementation includes both a native filesystem watcher and integration with IntelliJ's virtual file system events, and ensures the service is initialized on project startup.

### File Change Monitoring Feature

* Added `FileChangeService` to monitor both IntelliJ VFS events and native filesystem changes, automatically opening changed or newly created project files in the editor if enabled.
* Registered `FileChangeStartupActivity` to ensure `FileChangeService` is initialized after project startup via the plugin XML. [[1]](diffhunk://#diff-7dea19722c2c14e84c10a6617f9631bfef9c88f5f8645db6ad6c670ca6e7c613R1-R11) [[2]](diffhunk://#diff-13198d14dd3abf13abd9cb906331ed7d9663fc081757b6845fd5f3c1850b5693R53)

### Settings UI and State Management

* Introduced a new checkbox in the settings UI (`CodexLauncherConfigurable`) for "Open files automatically when changed", including state management and persistence for this option. [[1]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R7) [[2]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R23) [[3]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R45-R47) [[4]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R96-R100) [[5]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5L100-R111) [[6]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R125) [[7]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R135) [[8]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R156-R159) [[9]](diffhunk://#diff-2d35529cc90dbadb654dfeb5941bc31599efe8a8349b66ca44d85eb220872116L16-R17)

### Minor Cleanup

* Removed unused notification imports from `LaunchCodexAction.kt`.