### PR TITLE
Add gpt 5 codex model & reasoning effort selection

### DIFF
--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
@@ -32,6 +32,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
     private lateinit var modeFullAutoRadio: JBRadioButton
     private lateinit var modelCombo: JComboBox<Model>
     private lateinit var customModelField: JBTextField
+    private lateinit var modelReasoningEffortCombo: JComboBox<ModelReasoningEffort>
     private lateinit var openFileOnChangeCheckbox: JBCheckBox
     private lateinit var enableNotificationCheckbox: JBCheckBox
     private lateinit var isPowerShell73OrOverCheckbox: JBCheckBox
@@ -57,18 +58,21 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         customModelField = JBTextField()
         customModelField.emptyText.text = "e.g. gpt-5"
         customModelField.isEnabled = false
-        
+
+        // Model reasoning effort controls
+        modelReasoningEffortCombo = ComboBox(ModelReasoningEffort.entries.toTypedArray())
+
         // File opening control
         openFileOnChangeCheckbox = JBCheckBox("Open files automatically when changed")
-        
+
         // Notification control
         enableNotificationCheckbox = JBCheckBox("Enable notifications when events are completed by Codex CLI")
-        
+
         // PowerShell 7.3 mode control (Windows only)
         if (SystemInfo.isWindows) {
             isPowerShell73OrOverCheckbox = JBCheckBox("Using PowerShell 7.3 or later")
         }
-        
+
         // MCP Configuration controls
         mcpConfigInputArea = JBTextArea(5, 50)
         mcpConfigInputArea.font = Font(Font.MONOSPACED, Font.PLAIN, 12)
@@ -133,6 +137,12 @@ class CodexLauncherConfigurable : SearchableConfigurable {
                         .resizableColumn()
                         .applyToComponent { columns = 50 }
                 }
+                row {
+                    comment("Some models may not support all reasoning effort levels.")
+                }
+                row("Model reasoning effort") {
+                    cell(modelReasoningEffortCombo)
+                }
             }
             group("File Handling") {
                 row {
@@ -176,6 +186,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         return getMode() != s.mode ||
                 getModel() != s.model ||
                 getCustomModel() != s.customModel ||
+                getModelReasoningEffort() != s.modelReasoningEffort ||
                 getOpenFileOnChange() != s.openFileOnChange ||
                 getEnableNotification() != s.enableNotification ||
                 (SystemInfo.isWindows && getIsPowerShell73OrOver() != s.isPowerShell73OrOver) ||
@@ -193,6 +204,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         s.mode = getMode()
         s.model = getModel()
         s.customModel = getCustomModel()
+        s.modelReasoningEffort = getModelReasoningEffort()
         s.openFileOnChange = getOpenFileOnChange()
         s.enableNotification = getEnableNotification()
         if (SystemInfo.isWindows) {
@@ -208,6 +220,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         modelCombo.selectedItem = s.model
         customModelField.text = s.customModel
         customModelField.isEnabled = (s.model == Model.CUSTOM)
+        modelReasoningEffortCombo.selectedItem = s.modelReasoningEffort
         openFileOnChangeCheckbox.isSelected = s.openFileOnChange
         enableNotificationCheckbox.isSelected = s.enableNotification
         if (SystemInfo.isWindows) {
@@ -231,15 +244,19 @@ class CodexLauncherConfigurable : SearchableConfigurable {
     private fun getCustomModel(): String {
         return customModelField.text?.trim() ?: ""
     }
-    
+
+    private fun getModelReasoningEffort(): ModelReasoningEffort {
+        return (modelReasoningEffortCombo.selectedItem as? ModelReasoningEffort) ?: ModelReasoningEffort.DEFAULT
+    }
+
     private fun getOpenFileOnChange(): Boolean {
         return openFileOnChangeCheckbox.isSelected
     }
-    
+
     private fun getEnableNotification(): Boolean {
         return enableNotificationCheckbox.isSelected
     }
-    
+
     private fun getIsPowerShell73OrOver(): Boolean {
         return if (SystemInfo.isWindows) {
             isPowerShell73OrOverCheckbox.isSelected
@@ -247,7 +264,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
             false
         }
     }
-    
+
     private fun getMcpConfigInput(): String {
         return mcpConfigInputArea.text ?: ""
     }

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherSettings.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherSettings.kt
@@ -38,6 +38,7 @@ class CodexLauncherSettings : PersistentStateComponent<CodexLauncherSettings.Sta
         var mode: Mode = Mode.DEFAULT,
         var model: Model = Model.DEFAULT,
         var customModel: String = "",
+        var modelReasoningEffort: ModelReasoningEffort = ModelReasoningEffort.DEFAULT,
         var openFileOnChange: Boolean = false,
         var enableNotification: Boolean = false,
         var mcpConfigInput: String = "",

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/Model.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/Model.kt
@@ -7,6 +7,7 @@ enum class Model {
     /** Do not pass --model. */
     DEFAULT,
     GPT_5,
+    GPT_5_CODEX,
     CODEX_MINI_LATEST,
     /** Use customModel from settings. */
     CUSTOM;
@@ -14,6 +15,7 @@ enum class Model {
     fun cliName(): String = when (this) {
         DEFAULT -> ""
         GPT_5 -> "gpt-5"
+        GPT_5_CODEX -> "gpt-5-codex"
         CODEX_MINI_LATEST -> "codex-mini-latest"
         CUSTOM -> ""
     }
@@ -21,6 +23,7 @@ enum class Model {
     fun toDisplayName(): String = when (this) {
         DEFAULT -> "Default"
         GPT_5 -> "gpt-5"
+        GPT_5_CODEX -> "gpt-5-codex"
         CODEX_MINI_LATEST -> "codex-mini-latest"
         CUSTOM -> "Custom..."
     }

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/ModelReasoningEffort.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/ModelReasoningEffort.kt
@@ -1,0 +1,27 @@
+package com.github.x0x0b.codexlauncher.settings
+
+enum class ModelReasoningEffort {
+    DEFAULT,
+    MINIMAL,
+    LOW,
+    MEDIUM,
+    HIGH;
+
+    fun cliName(): String = when (this) {
+        DEFAULT -> ""
+        MINIMAL -> "minimal"
+        LOW -> "low"
+        MEDIUM -> "medium"
+        HIGH -> "high"
+    }
+
+    fun toDisplayName(): String = when (this) {
+        DEFAULT -> "Default"
+        MINIMAL -> "Minimal"
+        LOW -> "Low"
+        MEDIUM -> "Medium"
+        HIGH -> "High"
+    }
+
+    override fun toString(): String = toDisplayName()
+}

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilder.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilder.kt
@@ -2,6 +2,7 @@ package com.github.x0x0b.codexlauncher.util
 
 import com.github.x0x0b.codexlauncher.settings.CodexLauncherSettings
 import com.github.x0x0b.codexlauncher.settings.Model
+import com.github.x0x0b.codexlauncher.settings.ModelReasoningEffort
 import com.github.x0x0b.codexlauncher.settings.Mode
 import com.google.gson.JsonArray
 import com.google.gson.JsonParser
@@ -70,6 +71,16 @@ object CodexArgsBuilder {
         // Add model parameter if specified
         if (modelName != null) {
             parts += listOf("--model", "'${modelName}'")
+        }
+
+        // Add reasoning effort parameter if specified
+        val reasoningEffort: String? = when (state.modelReasoningEffort) {
+            ModelReasoningEffort.DEFAULT -> null // Use codex default
+            else -> state.modelReasoningEffort.cliName()
+        }
+
+        if (reasoningEffort != null) {
+            parts += createConfigArgument("model_reasoning_effort", reasoningEffort, osProvider)
         }
 
         // Add notify command if port is provided


### PR DESCRIPTION
This pull request adds support for configuring the "model reasoning effort" in the CodexLauncher settings, allowing users to select the desired reasoning effort level for the model. It introduces a new `ModelReasoningEffort` enum, updates the settings UI to include this option, persists the value, and ensures it is passed as a CLI argument when launching Codex. Additionally, a new model type, `GPT_5_CODEX`, is added.

**Model Reasoning Effort Support:**

* Added a new `ModelReasoningEffort` enum with CLI and display name helpers (`src/main/kotlin/com/github/x0x0b/codexlauncher/settings/ModelReasoningEffort.kt`).
* Updated `CodexLauncherConfigurable` to include a reasoning effort dropdown in the UI, persist its value, and restore it on load (`src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt`). [[1]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R35) [[2]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R62-R64) [[3]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R140-R145) [[4]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R189) [[5]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R207) [[6]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R223) [[7]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R248-R251) [[8]](diffhunk://#diff-2d35529cc90dbadb654dfeb5941bc31599efe8a8349b66ca44d85eb220872116R41)
* Modified `CodexArgsBuilder` to pass the selected reasoning effort as a CLI argument if specified (`src/main/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilder.kt`). [[1]](diffhunk://#diff-b5dd0e022f572c2bb06e2c6dde7c4c891994839be1457fbdbdc859fe3af08b84R5) [[2]](diffhunk://#diff-b5dd0e022f572c2bb06e2c6dde7c4c891994839be1457fbdbdc859fe3af08b84R76-R85)

**Model Options Update:**

* Added new model type `GPT_5_CODEX` to the `Model` enum, with CLI and display name support (`src/main/kotlin/com/github/x0x0b/codexlauncher/settings/Model.kt`).