### PR TITLE
feat: Windows WSL limited support

### DIFF
--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
@@ -20,6 +20,7 @@ import javax.swing.JComboBox
 import javax.swing.text.AbstractDocument
 import javax.swing.text.AttributeSet
 import javax.swing.text.DocumentFilter
+import java.awt.Component
 import java.awt.Font
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
@@ -27,6 +28,8 @@ import javax.swing.JButton
 import com.intellij.openapi.ui.Messages
 import com.google.gson.JsonParser
 import com.google.gson.JsonSyntaxException
+import javax.swing.DefaultListCellRenderer
+import javax.swing.JList
 
 class CodexLauncherConfigurable : SearchableConfigurable {
     private lateinit var root: JComponent
@@ -85,7 +88,23 @@ class CodexLauncherConfigurable : SearchableConfigurable {
 
         // Windows shell selection (Windows only)
         if (SystemInfo.isWindows) {
-            winShellCombo = ComboBox(WinShell.entries.toTypedArray())
+            winShellCombo = ComboBox(WinShell.entries.toTypedArray()).apply {
+                renderer = object : DefaultListCellRenderer() {
+                    override fun getListCellRendererComponent(
+                        list: JList<*>?,
+                        value: Any?,
+                        index: Int,
+                        isSelected: Boolean,
+                        cellHasFocus: Boolean
+                    ): Component {
+                        val component = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus)
+                        if (value is WinShell) {
+                            text = value.toDisplayName()
+                        }
+                        return component
+                    }
+                }
+            }
             winShellCombo.addActionListener { updateWslDependentAvailability() }
         }
 

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
@@ -157,7 +157,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
                         cell(winShellCombo)
                     }
                     row {
-                        comment("WSL will be treated the same as Mac/Linux for command formatting.")
+                        comment("Please choose the option that matches your environment, such as the PowerShell version or whether you are using WSL.")
                     }
                 }
             }

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
@@ -242,8 +242,8 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         s.enableNotification = getEnableNotification()
         if (SystemInfo.isWindows) {
             s.winShell = getWinShell()
-            // Keep legacy field in sync for backward compatibility
-            s.isPowerShell73OrOver = (s.winShell == WinShell.POWERSHELL_73_PLUS)
+            // update legacy field
+            s.isPowerShell73OrOver = false
         }
         s.mcpConfigInput = getMcpConfigInput()
     }

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
@@ -189,18 +189,18 @@ class CodexLauncherConfigurable : SearchableConfigurable {
             }
             group("File Handling") {
                 row {
-                    cell(openFileOnChangeCheckbox)
+                    cell(fileHandlingWarningLabel)
                 }
                 row {
-                    cell(fileHandlingWarningLabel)
+                    cell(openFileOnChangeCheckbox)
                 }
             }
             group("Notifications (Experimental)") {
                 row {
-                    cell(enableNotificationCheckbox)
+                    cell(notificationsWarningLabel)
                 }
                 row {
-                    cell(notificationsWarningLabel)
+                    cell(enableNotificationCheckbox)
                 }
                 row {
                     comment(
@@ -216,13 +216,13 @@ class CodexLauncherConfigurable : SearchableConfigurable {
             }
             group("Integrated MCP Server (Experimental)") {
                 row {
+                    cell(mcpServerWarningLabel)
+                }
+                row {
                     comment(
                         "In <a href='mcp'>Tools &gt; MCP Server</a>, click the Copy Stdio Config button and paste it into the input field below. (2025.2+)",
                         action = HyperlinkEventAction { openApplicationConfigurable(MCP_SERVER_CONFIGURABLE_ID) }
                     )
-                }
-                row {
-                    cell(mcpServerWarningLabel)
                 }
                 row("Stdio Config:") {
                     cell(JBScrollPane(mcpConfigInputArea))

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherSettings.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherSettings.kt
@@ -43,7 +43,7 @@ class CodexLauncherSettings : PersistentStateComponent<CodexLauncherSettings.Sta
         var openFileOnChange: Boolean = false,
         var enableNotification: Boolean = false,
         var mcpConfigInput: String = "",
-        var isPowerShell73OrOver: Boolean = false,
+        var isPowerShell73OrOver: Boolean = false, // Legacy flag, use winShell instead
         var winShell: WinShell = WinShell.POWERSHELL_LT_73
     )
 
@@ -52,6 +52,12 @@ class CodexLauncherSettings : PersistentStateComponent<CodexLauncherSettings.Sta
     override fun getState(): State = state
 
     override fun loadState(state: State) {
+        // Migrate legacy isPowerShell73OrOver flag to winShell enum
+        if (state.isPowerShell73OrOver) {
+            state.winShell = WinShell.POWERSHELL_73_PLUS
+            state.isPowerShell73OrOver = false
+        }
+
         XmlSerializerUtil.copyBean(state, this.state)
     }
 

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherSettings.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherSettings.kt
@@ -32,7 +32,8 @@ class CodexLauncherSettings : PersistentStateComponent<CodexLauncherSettings.Sta
      * @property customModel Custom model identifier when model is set to CUSTOM
      * @property openFileOnChange Whether to automatically open files when they change
      * @property enableNotification Whether to enable notifications
-     * @property isPowerShell73OrOver Whether using PowerShell 7.3 or later (enables compatible command formatting)
+     * @property isPowerShell73OrOver Whether using PowerShell 7.3 or later (legacy; use winShell instead)
+     * @property winShell Preferred Windows shell selection (Windows only)
      */
     data class State(
         var mode: Mode = Mode.DEFAULT,
@@ -41,7 +42,8 @@ class CodexLauncherSettings : PersistentStateComponent<CodexLauncherSettings.Sta
         var openFileOnChange: Boolean = false,
         var enableNotification: Boolean = false,
         var mcpConfigInput: String = "",
-        var isPowerShell73OrOver: Boolean = false
+        var isPowerShell73OrOver: Boolean = false,
+        var winShell: WinShell = WinShell.POWERSHELL_LT_73
     )
 
     private var state = State()

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/WinShell.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/WinShell.kt
@@ -1,0 +1,22 @@
+package com.github.x0x0b.codexlauncher.settings
+
+/**
+ * Windows shell selection for command formatting.
+ *
+ * - `POWERSHELL_LT_73`: PowerShell prior to 7.3 (legacy escaping)
+ * - `POWERSHELL_73_PLUS`: PowerShell 7.3 or later (modern escaping)
+ * - `WSL`: Windows Subsystem for Linux; treated like Mac/Linux in formatting
+ */
+enum class WinShell {
+    POWERSHELL_LT_73,
+    POWERSHELL_73_PLUS,
+    WSL;
+
+    fun toDisplayName(): String = when (this) {
+        POWERSHELL_LT_73 -> "PowerShell (< 7.3)"
+        POWERSHELL_73_PLUS -> "PowerShell (7.3+)"
+        WSL -> "WSL (bash/zsh)"
+    }
+
+    override fun toString(): String = toDisplayName()
+}

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/WinShell.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/WinShell.kt
@@ -15,7 +15,7 @@ enum class WinShell {
     fun toDisplayName(): String = when (this) {
         POWERSHELL_LT_73 -> "PowerShell (< 7.3)"
         POWERSHELL_73_PLUS -> "PowerShell (7.3+)"
-        WSL -> "WSL (bash/zsh)"
+        WSL -> "WSL"
     }
 
     override fun toString(): String = toDisplayName()

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/WinShell.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/WinShell.kt
@@ -17,6 +17,4 @@ enum class WinShell {
         POWERSHELL_73_PLUS -> "PowerShell (7.3+)"
         WSL -> "WSL"
     }
-
-    override fun toString(): String = toDisplayName()
 }

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilder.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilder.kt
@@ -91,8 +91,11 @@ object CodexArgsBuilder {
             parts += buildNotifyCommand(port, osProvider, state.winShell)
         }
 
-        // Add MCP configuration if specified
-        parts += buildMcpConfigArgs(state.mcpConfigInput, osProvider, state.winShell)
+        // Add MCP configuration if specified and not using WSL
+        // TODO: resolve WSL SSEClientException error with MCP
+        if (!osProvider.isWindows || state.winShell != WinShell.WSL) {
+            parts += buildMcpConfigArgs(state.mcpConfigInput, osProvider, state.winShell)
+        }
 
         return parts
     }

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilder.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilder.kt
@@ -83,12 +83,12 @@ object CodexArgsBuilder {
         }
 
         if (reasoningEffort != null) {
-            parts += createConfigArgument("model_reasoning_effort", reasoningEffort, osProvider)
+            parts += createConfigArgument("model_reasoning_effort", reasoningEffort, osProvider, state.winShell)
         }
 
         // Add notify command if port is provided
         if (port != null) {
-            parts += buildNotifyCommand(port,osProvider, state.winShell)
+            parts += buildNotifyCommand(port, osProvider, state.winShell)
         }
 
         // Add MCP configuration if specified

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilder.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilder.kt
@@ -85,7 +85,7 @@ object CodexArgsBuilder {
         }
 
         // Windows/WSL ignores notify and MCP config
-        if (!osProvider.isWindows || state.winShell != WinShell.WSL) {
+        if (!(osProvider.isWindows && state.winShell == WinShell.WSL)) {
             // Add notify command if port is provided and not using WSL
             if (port != null) {
                 parts += buildNotifyCommand(port, osProvider, state.winShell)

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilder.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilder.kt
@@ -86,14 +86,14 @@ object CodexArgsBuilder {
             parts += createConfigArgument("model_reasoning_effort", reasoningEffort, osProvider, state.winShell)
         }
 
-        // Add notify command if port is provided
-        if (port != null) {
-            parts += buildNotifyCommand(port, osProvider, state.winShell)
-        }
-
-        // Add MCP configuration if specified and not using WSL
-        // TODO: resolve WSL SSEClientException error with MCP
+        // TODO: resolve WSL issue with notify and mcp config
         if (!osProvider.isWindows || state.winShell != WinShell.WSL) {
+            // Add notify command if port is provided and not using WSL
+            if (port != null) {
+                parts += buildNotifyCommand(port, osProvider, state.winShell)
+            }
+
+            // Add MCP configuration if specified and not using WSL
             parts += buildMcpConfigArgs(state.mcpConfigInput, osProvider, state.winShell)
         }
 

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilder.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilder.kt
@@ -39,8 +39,6 @@ object DefaultOsProvider : OsProvider {
  * @since 1.0.0
  */
 object CodexArgsBuilder {
-    private val WINDOWS_DRIVE_REGEX = Regex("""^[A-Za-z]:\\.*""")
-
     /**
      * Builds the command-line argument list for codex based on the provided settings state.
      * 

--- a/src/test/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilderTest.kt
+++ b/src/test/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilderTest.kt
@@ -180,15 +180,15 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         val result = CodexArgsBuilder.build(state, 44444, osProvider = osProvider)
 
         // Verify non-Windows style quoting and no SystemRoot
-        assertEquals(7, result.size)
+        assertEquals(5, result.size)
         assertEquals("""--full-auto""", result[0])
         assertEquals("""--model""", result[1])
         assertEquals("""'gpt-4o'""", result[2])
         assertEquals("""-c""", result[3])
         assertEquals("""'model_reasoning_effort=high'""", result[4])
-        assertEquals("""-c""", result[5])
-        assertEquals("""'notify=["curl", "-s", "-X", "POST", "http://localhost:44444/refresh", "-d"]'""", result[6])
         // TODO: Enable these after fixing the errors
+//        assertEquals("""-c""", result[5])
+//        assertEquals("""'notify=["curl", "-s", "-X", "POST", "http://localhost:44444/refresh", "-d"]'""", result[6])
 //        assertEquals("""-c""", result[7])
 //        assertEquals(
 //            """'mcp_servers.intellij.command=/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/jbr/bin/java'""",

--- a/src/test/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilderTest.kt
+++ b/src/test/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilderTest.kt
@@ -165,12 +165,12 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         assertEquals("""'notify=["curl", "-s", "-X", "POST", "http://localhost:44444/refresh", "-d"]'""", result[4])
         assertEquals("""-c""", result[5])
         assertEquals(
-            """'mcp_servers.intellij.command='""",
+            """'mcp_servers.intellij.command=/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/jbr/bin/java'""",
             result[6]
         )
         assertEquals("""-c""", result[7])
         assertEquals(
-            """'mcp_servers.intellij.args=[]'""",
+            """'mcp_servers.intellij.args=["-classpath", "/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/plugins/mcpserver/lib/mcpserver-frontend.jar:/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/lib/util-8.jar", "com.intellij.mcpserver.stdio.McpStdioRunnerKt"]'""",
             result[8]
         )
         assertEquals("""-c""", result[9])

--- a/src/test/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilderTest.kt
+++ b/src/test/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilderTest.kt
@@ -128,6 +128,7 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         val osProvider = TestOsProvider(isWindows = true)
         state.winShell = WinShell.POWERSHELL_73_PLUS
         state.mcpConfigInput = mcpWindows
+
         val result = CodexArgsBuilder.build(state, 33333, osProvider = osProvider)
 
         // Verify that complex arguments are properly formatted for Windows with PowerShell 7.3+

--- a/src/test/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilderTest.kt
+++ b/src/test/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilderTest.kt
@@ -180,23 +180,25 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         val result = CodexArgsBuilder.build(state, 44444, osProvider = osProvider)
 
         // Verify non-Windows style quoting and no SystemRoot
-        assertEquals(11, result.size)
+        assertEquals(13, result.size)
         assertEquals("""--full-auto""", result[0])
         assertEquals("""--model""", result[1])
         assertEquals("""'gpt-4o'""", result[2])
         assertEquals("""-c""", result[3])
-        assertEquals("""'notify=["curl", "-s", "-X", "POST", "http://localhost:44444/refresh", "-d"]'""", result[4])
+        assertEquals("""'model_reasoning_effort=high'""", result[4])
         assertEquals("""-c""", result[5])
-        assertEquals(
-            """'mcp_servers.intellij.command=/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/jbr/bin/java'""",
-            result[6]
-        )
+        assertEquals("""'notify=["curl", "-s", "-X", "POST", "http://localhost:44444/refresh", "-d"]'""", result[6])
         assertEquals("""-c""", result[7])
         assertEquals(
-            """'mcp_servers.intellij.args=["-classpath", "/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/plugins/mcpserver/lib/mcpserver-frontend.jar:/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/lib/util-8.jar", "com.intellij.mcpserver.stdio.McpStdioRunnerKt"]'""",
+            """'mcp_servers.intellij.command=/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/jbr/bin/java'""",
             result[8]
         )
         assertEquals("""-c""", result[9])
-        assertEquals("""'mcp_servers.intellij.env={"IJ_MCP_SERVER_PORT"="64342"}'""", result[10])
+        assertEquals(
+            """'mcp_servers.intellij.args=["-classpath", "/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/plugins/mcpserver/lib/mcpserver-frontend.jar:/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/lib/util-8.jar", "com.intellij.mcpserver.stdio.McpStdioRunnerKt"]'""",
+            result[10]
+        )
+        assertEquals("""-c""", result[11])
+        assertEquals("""'mcp_servers.intellij.env={"IJ_MCP_SERVER_PORT"="64342"}'""", result[12])
     }
 }

--- a/src/test/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilderTest.kt
+++ b/src/test/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilderTest.kt
@@ -186,20 +186,5 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         assertEquals("""'gpt-4o'""", result[2])
         assertEquals("""-c""", result[3])
         assertEquals("""'model_reasoning_effort=high'""", result[4])
-        // TODO: Enable these after fixing the errors
-//        assertEquals("""-c""", result[5])
-//        assertEquals("""'notify=["curl", "-s", "-X", "POST", "http://localhost:44444/refresh", "-d"]'""", result[6])
-//        assertEquals("""-c""", result[7])
-//        assertEquals(
-//            """'mcp_servers.intellij.command=/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/jbr/bin/java'""",
-//            result[8]
-//        )
-//        assertEquals("""-c""", result[9])
-//        assertEquals(
-//            """'mcp_servers.intellij.args=["-classpath", "/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/plugins/mcpserver/lib/mcpserver-frontend.jar:/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/lib/util-8.jar", "com.intellij.mcpserver.stdio.McpStdioRunnerKt"]'""",
-//            result[10]
-//        )
-//        assertEquals("""-c""", result[11])
-//        assertEquals("""'mcp_servers.intellij.env={"IJ_MCP_SERVER_PORT"="64342"}'""", result[12])
     }
 }

--- a/src/test/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilderTest.kt
+++ b/src/test/kotlin/com/github/x0x0b/codexlauncher/util/CodexArgsBuilderTest.kt
@@ -180,7 +180,7 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         val result = CodexArgsBuilder.build(state, 44444, osProvider = osProvider)
 
         // Verify non-Windows style quoting and no SystemRoot
-        assertEquals(13, result.size)
+        assertEquals(7, result.size)
         assertEquals("""--full-auto""", result[0])
         assertEquals("""--model""", result[1])
         assertEquals("""'gpt-4o'""", result[2])
@@ -188,17 +188,18 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         assertEquals("""'model_reasoning_effort=high'""", result[4])
         assertEquals("""-c""", result[5])
         assertEquals("""'notify=["curl", "-s", "-X", "POST", "http://localhost:44444/refresh", "-d"]'""", result[6])
-        assertEquals("""-c""", result[7])
-        assertEquals(
-            """'mcp_servers.intellij.command=/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/jbr/bin/java'""",
-            result[8]
-        )
-        assertEquals("""-c""", result[9])
-        assertEquals(
-            """'mcp_servers.intellij.args=["-classpath", "/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/plugins/mcpserver/lib/mcpserver-frontend.jar:/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/lib/util-8.jar", "com.intellij.mcpserver.stdio.McpStdioRunnerKt"]'""",
-            result[10]
-        )
-        assertEquals("""-c""", result[11])
-        assertEquals("""'mcp_servers.intellij.env={"IJ_MCP_SERVER_PORT"="64342"}'""", result[12])
+        // TODO: Enable these after fixing the errors
+//        assertEquals("""-c""", result[7])
+//        assertEquals(
+//            """'mcp_servers.intellij.command=/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/jbr/bin/java'""",
+//            result[8]
+//        )
+//        assertEquals("""-c""", result[9])
+//        assertEquals(
+//            """'mcp_servers.intellij.args=["-classpath", "/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/plugins/mcpserver/lib/mcpserver-frontend.jar:/mnt/c/Program Files/JetBrains/IntelliJ IDEA Community Edition 2025.2.1/lib/util-8.jar", "com.intellij.mcpserver.stdio.McpStdioRunnerKt"]'""",
+//            result[10]
+//        )
+//        assertEquals("""-c""", result[11])
+//        assertEquals("""'mcp_servers.intellij.env={"IJ_MCP_SERVER_PORT"="64342"}'""", result[12])
     }
 }


### PR DESCRIPTION
This pull request refactors Windows shell selection and related settings in the CodexLauncher plugin, replacing the old PowerShell version checkbox with a more flexible shell selection dropdown. It also introduces logic to disable certain features and display warnings when WSL is selected, and updates argument-building logic to use the new shell enum. Additionally, it migrates legacy settings for backward compatibility.

**Windows Shell Selection and Settings Refactor:**

* Replaced the `isPowerShell73OrOver` checkbox with a new `winShell` dropdown in the settings UI, allowing users to choose between PowerShell (<7.3), PowerShell (7.3+), and WSL. Added the `WinShell` enum to represent these options. (`CodexLauncherConfigurable.kt`, `WinShell.kt`) [[1]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R77-R110) [[2]](diffhunk://#diff-7f0f79857272bfea48a27084cc52b19bde7ad9329856c506581e6e11a464b37dR1-R20)
* Updated the settings data model (`CodexLauncherSettings.State`) to store the selected shell as a `winShell` enum, with migration logic from the legacy boolean field for backward compatibility. (`CodexLauncherSettings.kt`) [[1]](diffhunk://#diff-2d35529cc90dbadb654dfeb5941bc31599efe8a8349b66ca44d85eb220872116L35-R36) [[2]](diffhunk://#diff-2d35529cc90dbadb654dfeb5941bc31599efe8a8349b66ca44d85eb220872116L45-R60)

**WSL-Dependent Feature Availability:**

* Added warning labels and logic to disable MCP Server, file handling, and notifications when WSL is selected as the shell, both visually in the UI and functionally in the code. (`CodexLauncherConfigurable.kt`) [[1]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R120-R125) [[2]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R191-R201) [[3]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R218-R220) [[4]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R239-R240) [[5]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5L267-R366)

**Argument Construction Updates:**

* Refactored argument construction in `CodexArgsBuilder` to use the new `winShell` enum, ensuring correct command formatting and disabling MCP/notification arguments when WSL is selected. (`CodexArgsBuilder.kt`) [[1]](diffhunk://#diff-b5dd0e022f572c2bb06e2c6dde7c4c891994839be1457fbdbdc859fe3af08b84R7) [[2]](diffhunk://#diff-b5dd0e022f572c2bb06e2c6dde7c4c891994839be1457fbdbdc859fe3af08b84L83-R96) [[3]](diffhunk://#diff-b5dd0e022f572c2bb06e2c6dde7c4c891994839be1457fbdbdc859fe3af08b84L108-R112) [[4]](diffhunk://#diff-b5dd0e022f572c2bb06e2c6dde7c4c891994839be1457fbdbdc859fe3af08b84L126-R142) [[5]](diffhunk://#diff-b5dd0e022f572c2bb06e2c6dde7c4c891994839be1457fbdbdc859fe3af08b84L152-R161)

**UI and Code Cleanup:**

* Removed the legacy PowerShell 7.3 compatibility group from the UI and replaced it with the new shell selection group. (`CodexLauncherConfigurable.kt`)

**State Synchronization and Migration:**

* Updated state synchronization methods to use the new shell selection and ensure legacy fields are handled correctly. (`CodexLauncherConfigurable.kt`, `CodexLauncherSettings.kt`) [[1]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5L234-R292) [[2]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5L218-R273) [[3]](diffhunk://#diff-2d35529cc90dbadb654dfeb5941bc31599efe8a8349b66ca44d85eb220872116L45-R60)