### PR TITLE
feat: improve terminal launch by focusing existing Codex terminal if running

### DIFF
--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/LaunchCodexAction.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/LaunchCodexAction.kt
@@ -1,21 +1,28 @@
 package com.github.x0x0b.codexlauncher
 
 import com.github.x0x0b.codexlauncher.settings.CodexLauncherSettings
+import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
-import com.intellij.notification.NotificationGroupManager
-import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.terminal.ui.TerminalWidget
+import com.intellij.ui.content.Content
+import org.jetbrains.plugins.terminal.TerminalToolWindowManager
+import org.jetbrains.plugins.terminal.TerminalToolWindowFactory
 
 class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null), DumbAware {
     
     companion object {
         private const val CODEX_COMMAND = "codex"
         private const val NOTIFICATION_TITLE = "Codex Launcher"
+        private val CODEX_TERMINAL_KEY = Key.create<Boolean>("codex.launcher.codexTerminal")
     }
     
     private val logger = logger<LaunchCodexAction>()
@@ -29,10 +36,15 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
         val baseDir = project.basePath ?: System.getProperty("user.home")
         logger.info("Launching Codex in directory: $baseDir")
 
-        try {
-            val terminalView = org.jetbrains.plugins.terminal.TerminalToolWindowManager.getInstance(project)
-            val widget = terminalView.createShellWidget(baseDir, "Codex", true, true)
+        val terminalManager = TerminalToolWindowManager.getInstance(project)
 
+        findRunningCodexWidget(terminalManager)?.let { existingWidget ->
+            logger.info("Found running Codex terminal; focusing existing tab instead of launching a new one")
+            focusExistingCodexTerminal(project, terminalManager, existingWidget)
+            return
+        }
+
+        try {
             val httpService = ApplicationManager.getApplication().service<HttpTriggerService>()
             val port = httpService.getActualPort()
             
@@ -46,7 +58,15 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
             val args = settings.getArgs(port)
             
             val command = buildCommand(args)
-            widget.sendCommandToExecute(command)
+            var widget: TerminalWidget? = null
+            try {
+                widget = terminalManager.createShellWidget(baseDir, "Codex", true, true)
+                markCodexTerminal(terminalManager, widget)
+                widget.sendCommandToExecute(command)
+            } catch (sendError: Throwable) {
+                widget?.let { clearCodexMetadata(terminalManager, it) }
+                throw sendError
+            }
             
             logger.info("Codex command executed successfully: $command")
             
@@ -55,7 +75,7 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
             notify(project, "Failed to launch Codex: ${t.message}", NotificationType.ERROR)
         }
     }
-    
+
     private fun buildCommand(args: String): String {
         return buildString {
             append(CODEX_COMMAND)
@@ -64,6 +84,93 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
                 append(args)
             }
         }
+    }
+
+    private fun findRunningCodexWidget(manager: TerminalToolWindowManager): TerminalWidget? {
+        return try {
+            manager.terminalWidgets.firstOrNull { widget ->
+                val content = manager.getContainer(widget)?.content
+                if (content?.getUserData(CODEX_TERMINAL_KEY) != true) {
+                    return@firstOrNull false
+                }
+
+                if (!widget.isCommandRunning()) {
+                    content.putUserData(CODEX_TERMINAL_KEY, null)
+                    return@firstOrNull false
+                }
+
+                true
+            }
+        } catch (t: Throwable) {
+            logger.warn("Failed to inspect existing terminal widgets", t)
+            null
+        }
+    }
+
+    private fun focusExistingCodexTerminal(
+        project: Project,
+        manager: TerminalToolWindowManager,
+        widget: TerminalWidget
+    ) {
+        ApplicationManager.getApplication().invokeLater {
+            if (project.isDisposed) {
+                return@invokeLater
+            }
+
+            try {
+                val container = manager.getContainer(widget) ?: return@invokeLater
+                val content = container.content ?: return@invokeLater
+                val toolWindow = manager.getToolWindow()
+                    ?: ToolWindowManager.getInstance(project)
+                        .getToolWindow(TerminalToolWindowFactory.TOOL_WINDOW_ID)
+                if (toolWindow == null) {
+                    logger.warn("Terminal tool window is not available for focusing Codex")
+                    return@invokeLater
+                }
+
+                val contentManager = toolWindow.contentManager
+                if (contentManager.selectedContent != content) {
+                    contentManager.setSelectedContent(content, true)
+                }
+
+                toolWindow.activate({
+                    try {
+                        widget.requestFocus()
+                    } catch (focusError: Throwable) {
+                        logger.warn("Failed to request focus for Codex terminal", focusError)
+                    }
+                }, true)
+            } catch (focusError: Throwable) {
+                logger.warn("Failed to focus existing Codex terminal", focusError)
+            }
+        }
+    }
+
+    private fun markCodexTerminal(
+        manager: TerminalToolWindowManager,
+        widget: TerminalWidget
+    ) {
+        try {
+            val content = manager.getContainer(widget)?.content ?: return
+            content.putUserData(CODEX_TERMINAL_KEY, true)
+        } catch (t: Throwable) {
+            logger.warn("Failed to tag Codex terminal metadata", t)
+        }
+    }
+
+    private fun clearCodexMetadata(manager: TerminalToolWindowManager, widget: TerminalWidget) {
+        try {
+            val content = manager.getContainer(widget)?.content
+            if (content != null) {
+                clearCodexMetadata(content)
+            }
+        } catch (t: Throwable) {
+            logger.warn("Failed to clear Codex terminal metadata", t)
+        }
+    }
+
+    private fun clearCodexMetadata(content: Content) {
+        content.putUserData(CODEX_TERMINAL_KEY, null)
     }
 
     private fun notify(project: Project, content: String, type: NotificationType) {

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/LaunchCodexAction.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/LaunchCodexAction.kt
@@ -26,6 +26,8 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
     }
     
     private val logger = logger<LaunchCodexAction>()
+
+    private data class CodexTerminal(val widget: TerminalWidget, val content: Content)
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project
         if (project == null) {
@@ -38,9 +40,9 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
 
         val terminalManager = TerminalToolWindowManager.getInstance(project)
 
-        findRunningCodexWidget(terminalManager)?.let { existingWidget ->
+        locateCodexTerminal(terminalManager)?.let { codexTerminal ->
             logger.info("Found running Codex terminal; focusing existing tab instead of launching a new one")
-            focusExistingCodexTerminal(project, terminalManager, existingWidget)
+            focusExistingCodexTerminal(project, terminalManager, codexTerminal)
             return
         }
 
@@ -86,21 +88,21 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
         }
     }
 
-    private fun findRunningCodexWidget(manager: TerminalToolWindowManager): TerminalWidget? {
+    private fun locateCodexTerminal(manager: TerminalToolWindowManager): CodexTerminal? {
         return try {
-            manager.terminalWidgets.firstOrNull { widget ->
-                val content = manager.getContainer(widget)?.content
-                if (content?.getUserData(CODEX_TERMINAL_KEY) != true) {
-                    return@firstOrNull false
+            manager.terminalWidgets.asSequence().mapNotNull { widget ->
+                val content = manager.getContainer(widget)?.content ?: return@mapNotNull null
+                if (content.getUserData(CODEX_TERMINAL_KEY) != true) {
+                    return@mapNotNull null
                 }
 
                 if (!widget.isCommandRunning()) {
-                    content.putUserData(CODEX_TERMINAL_KEY, null)
-                    return@firstOrNull false
+                    clearCodexMetadata(content)
+                    return@mapNotNull null
                 }
 
-                true
-            }
+                CodexTerminal(widget, content)
+            }.firstOrNull()
         } catch (t: Throwable) {
             logger.warn("Failed to inspect existing terminal widgets", t)
             null
@@ -110,7 +112,7 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
     private fun focusExistingCodexTerminal(
         project: Project,
         manager: TerminalToolWindowManager,
-        widget: TerminalWidget
+        terminal: CodexTerminal
     ) {
         ApplicationManager.getApplication().invokeLater {
             if (project.isDisposed) {
@@ -118,24 +120,20 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
             }
 
             try {
-                val container = manager.getContainer(widget) ?: return@invokeLater
-                val content = container.content ?: return@invokeLater
-                val toolWindow = manager.getToolWindow()
-                    ?: ToolWindowManager.getInstance(project)
-                        .getToolWindow(TerminalToolWindowFactory.TOOL_WINDOW_ID)
+                val toolWindow = resolveTerminalToolWindow(project, manager)
                 if (toolWindow == null) {
                     logger.warn("Terminal tool window is not available for focusing Codex")
                     return@invokeLater
                 }
 
                 val contentManager = toolWindow.contentManager
-                if (contentManager.selectedContent != content) {
-                    contentManager.setSelectedContent(content, true)
+                if (contentManager.selectedContent != terminal.content) {
+                    contentManager.setSelectedContent(terminal.content, true)
                 }
 
                 toolWindow.activate({
                     try {
-                        widget.requestFocus()
+                        terminal.widget.requestFocus()
                     } catch (focusError: Throwable) {
                         logger.warn("Failed to request focus for Codex terminal", focusError)
                     }
@@ -146,13 +144,21 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
         }
     }
 
+    private fun resolveTerminalToolWindow(
+        project: Project,
+        manager: TerminalToolWindowManager
+    ) = manager.getToolWindow()
+        ?: ToolWindowManager.getInstance(project)
+            .getToolWindow(TerminalToolWindowFactory.TOOL_WINDOW_ID)
+
     private fun markCodexTerminal(
         manager: TerminalToolWindowManager,
         widget: TerminalWidget
     ) {
         try {
-            val content = manager.getContainer(widget)?.content ?: return
-            content.putUserData(CODEX_TERMINAL_KEY, true)
+            manager.getContainer(widget)?.content?.let { content ->
+                content.putUserData(CODEX_TERMINAL_KEY, true)
+            }
         } catch (t: Throwable) {
             logger.warn("Failed to tag Codex terminal metadata", t)
         }
@@ -160,8 +166,7 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
 
     private fun clearCodexMetadata(manager: TerminalToolWindowManager, widget: TerminalWidget) {
         try {
-            val content = manager.getContainer(widget)?.content
-            if (content != null) {
+            manager.getContainer(widget)?.content?.let { content ->
                 clearCodexMetadata(content)
             }
         } catch (t: Throwable) {


### PR DESCRIPTION
This pull request refactors and enhances the Codex terminal launching logic in `LaunchCodexAction.kt`. The main improvements are focused on preventing duplicate Codex terminals, improving user experience by reusing existing terminals, and robustly managing metadata to track Codex terminals.

### Codex terminal management and user experience

* Added logic to detect if a Codex terminal is already running and, if so, focus the existing terminal tab instead of launching a new one. This prevents duplicate terminals and improves usability.
* Introduced a metadata key (`CODEX_TERMINAL_KEY`) and related functions (`markCodexTerminal`, `clearCodexMetadata`, `locateCodexTerminal`) to tag and identify Codex terminals, ensuring accurate detection and cleanup. [[1]](diffhunk://#diff-c76c692bb62a511fff82d31e6a0f3a7c3903806d596d71ddef15338879458524R4-R30) [[2]](diffhunk://#diff-c76c692bb62a511fff82d31e6a0f3a7c3903806d596d71ddef15338879458524R91-R180)
* Implemented `focusExistingCodexTerminal` and `resolveTerminalToolWindow` methods to reliably bring the Codex terminal tab to the foreground when it already exists.

### Terminal creation and error handling

* Updated terminal creation logic to mark new terminals as Codex terminals and ensure metadata is cleared if terminal command execution fails, preventing stale metadata.

These changes make the Codex launcher more robust and user-friendly by eliminating redundant terminals and improving terminal tab focus behavior.