### PR TITLE
feat: add links to open MCP Server and Notifications settings

### DIFF
--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
@@ -13,6 +13,7 @@ import com.intellij.ui.components.JBRadioButton
 import com.intellij.ui.components.JBTextField
 import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.dsl.builder.HyperlinkEventAction
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.HyperlinkLabel
 import com.intellij.util.ui.JBUI
@@ -160,12 +161,10 @@ class CodexLauncherConfigurable : SearchableConfigurable {
                     cell(enableNotificationCheckbox)
                 }
                 row {
-                    comment("Customize notification sounds and display options in Settings | Appearance & Behavior | Notifications | CodexLauncher.")
-                }
-                row {
-                    link("Open Notifications settings") {
-                        openApplicationConfigurable(NOTIFICATIONS_CONFIGURABLE_ID)
-                    }
+                    comment(
+                        "Customize notification sounds and display options in <a href='notifications'>Settings &gt; Appearance &amp; Behavior &gt; Notifications &gt; CodexLauncher</a>.",
+                        action = HyperlinkEventAction { openApplicationConfigurable(NOTIFICATIONS_CONFIGURABLE_ID) }
+                    )
                 }
                 row {
                     val link = HyperlinkLabel("Learn more about IntelliJ notification settings")
@@ -175,12 +174,10 @@ class CodexLauncherConfigurable : SearchableConfigurable {
             }
             group("Integrated MCP Server (Experimental)") {
                 row {
-                    comment("In Tools > MCP Server, click the Copy Stdio Config button and paste it into the input field below. (2025.2+)")
-                }
-                row {
-                    link("Open MCP Server settings") {
-                        openApplicationConfigurable(MCP_SERVER_CONFIGURABLE_ID)
-                    }
+                    comment(
+                        "In <a href='mcp'>Tools &gt; MCP Server</a>, click the Copy Stdio Config button and paste it into the input field below. (2025.2+)",
+                        action = HyperlinkEventAction { openApplicationConfigurable(MCP_SERVER_CONFIGURABLE_ID) }
+                    )
                 }
                 row("Stdio Config:") {
                     cell(JBScrollPane(mcpConfigInputArea))

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
@@ -1,11 +1,13 @@
 package com.github.x0x0b.codexlauncher.settings
 
+import com.intellij.ide.DataManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.options.ex.Settings
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBRadioButton
 import com.intellij.ui.components.JBTextField
@@ -284,6 +286,16 @@ class CodexLauncherConfigurable : SearchableConfigurable {
     }
 
     private fun openApplicationConfigurable(configurableId: String) {
+        val dataContext = DataManager.getInstance().getDataContext(root)
+        val settings = Settings.KEY.getData(dataContext)
+        if (settings != null) {
+            val target = settings.find(configurableId)
+            if (target != null) {
+                settings.select(target)
+                return
+            }
+        }
+
         val predicate = Predicate<com.intellij.openapi.options.Configurable> { configurable ->
             configurable is SearchableConfigurable && configurable.id == configurableId
         }

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherConfigurable.kt
@@ -1,8 +1,9 @@
 package com.github.x0x0b.codexlauncher.settings
 
 import com.intellij.openapi.components.service
-import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.options.ConfigurationException
+import com.intellij.openapi.options.SearchableConfigurable
+import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.ui.components.JBCheckBox
@@ -21,8 +22,9 @@ import javax.swing.text.DocumentFilter
 import java.awt.Font
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
+import java.util.function.Consumer
+import java.util.function.Predicate
 import javax.swing.JButton
-import com.intellij.openapi.ui.Messages
 import com.google.gson.JsonParser
 import com.google.gson.JsonSyntaxException
 
@@ -42,6 +44,8 @@ class CodexLauncherConfigurable : SearchableConfigurable {
 
     companion object {
         private val ALLOWED_CUSTOM_MODEL_REGEX = Regex("^[A-Za-z0-9._-]*$")
+        private const val MCP_SERVER_CONFIGURABLE_ID = "com.intellij.mcpserver.settings"
+        private const val NOTIFICATIONS_CONFIGURABLE_ID = "reference.settings.ide.settings.notifications"
     }
 
     override fun getId(): String = "com.github.x0x0b.codexlauncher.settings"
@@ -157,6 +161,11 @@ class CodexLauncherConfigurable : SearchableConfigurable {
                     comment("Customize notification sounds and display options in Settings | Appearance & Behavior | Notifications | CodexLauncher.")
                 }
                 row {
+                    link("Open Notifications settings") {
+                        openApplicationConfigurable(NOTIFICATIONS_CONFIGURABLE_ID)
+                    }
+                }
+                row {
                     val link = HyperlinkLabel("Learn more about IntelliJ notification settings")
                     link.setHyperlinkTarget("https://www.jetbrains.com/help/idea/notifications.html")
                     cell(link)
@@ -165,6 +174,11 @@ class CodexLauncherConfigurable : SearchableConfigurable {
             group("Integrated MCP Server (Experimental)") {
                 row {
                     comment("In Tools > MCP Server, click the Copy Stdio Config button and paste it into the input field below. (2025.2+)")
+                }
+                row {
+                    link("Open MCP Server settings") {
+                        openApplicationConfigurable(MCP_SERVER_CONFIGURABLE_ID)
+                    }
                 }
                 row("Stdio Config:") {
                     cell(JBScrollPane(mcpConfigInputArea))
@@ -268,4 +282,15 @@ class CodexLauncherConfigurable : SearchableConfigurable {
     private fun getMcpConfigInput(): String {
         return mcpConfigInputArea.text ?: ""
     }
+
+    private fun openApplicationConfigurable(configurableId: String) {
+        val predicate = Predicate<com.intellij.openapi.options.Configurable> { configurable ->
+            configurable is SearchableConfigurable && configurable.id == configurableId
+        }
+        val noopConsumer = Consumer<com.intellij.openapi.options.Configurable> { }
+        runCatching {
+            ShowSettingsUtil.getInstance().showSettingsDialog(null, predicate, noopConsumer)
+        }
+    }
+
 }


### PR DESCRIPTION
This pull request enhances the user experience in the `CodexLauncherConfigurable` settings panel by adding interactive hyperlinks that directly open related IntelliJ settings sections, specifically for notifications and MCP Server configuration. Additionally, it introduces a utility method to handle navigation to these settings programmatically and updates relevant comments to include clickable links.

**User experience improvements:**

* Added clickable hyperlinks to comments for notifications and MCP Server settings, allowing users to jump directly to the relevant configuration sections from the CodexLauncher settings panel. [[1]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5L157-R167) [[2]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5L167-R180)

**Navigation logic:**

* Implemented the `openApplicationConfigurable` method to programmatically open a specified settings panel using its configurable ID, improving integration with IntelliJ's settings navigation.
* Defined constants for the configurable IDs of Notifications and MCP Server settings for easier reference and maintainability.

**Imports and code organization:**

* Added necessary imports for navigation and hyperlink handling, including `DataManager`, `ShowSettingsUtil`, `Settings`, and `HyperlinkEventAction`. [[1]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R3-R16) [[2]](diffhunk://#diff-9ed05a712132181227331b4b362488371ddfa4581ef8a0972e2c82bdb282ecc5R28-L25)