### PR TITLE
fix: disable passing notify on default settings

### DIFF
--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilder.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilder.kt
@@ -87,7 +87,7 @@ object CodexArgsBuilder {
         // Windows/WSL ignores notify and MCP config
         if (!(osProvider.isWindows && state.winShell == WinShell.WSL)) {
             // Add notify command if port is provided and not using WSL
-            if (port != null) {
+            if (port != null && (state.enableNotification || state.openFileOnChange)) {
                 parts += buildNotifyCommand(port, osProvider, state.winShell)
             }
 

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/ui/CodexLauncherConfigurable.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/ui/CodexLauncherConfigurable.kt
@@ -207,8 +207,11 @@ class CodexLauncherConfigurable : SearchableConfigurable {
                 row {
                     cell(openFileOnChangeCheckbox)
                 }
+                row {
+                    this.largeComment("Changes will take effect after restarting Codex.")
+                }
             }
-            group("Notifications (Experimental)") {
+            group("Notifications") {
                 row {
                     cell(notificationsWarningLabel)
                 }
@@ -220,6 +223,9 @@ class CodexLauncherConfigurable : SearchableConfigurable {
                         "Customize notification sounds and display options in <a href='notifications'>Settings &gt; Appearance &amp; Behavior &gt; Notifications &gt; CodexLauncher</a>.",
                         action = HyperlinkEventAction { openApplicationConfigurable(NOTIFICATIONS_CONFIGURABLE_ID) }
                     )
+                }
+                row {
+                    this.largeComment("Changes will take effect after restarting Codex.")
                 }
                 row {
                     val link = HyperlinkLabel("Learn more about IntelliJ notification settings")

--- a/src/test/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilderTest.kt
+++ b/src/test/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilderTest.kt
@@ -63,6 +63,7 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         // Test non-Windows formatting
         val osProvider = TestOsProvider(isWindows = false)
         state.mcpConfigInput = mcpNonWindows
+        state.enableNotification = true
 
         val result = CodexArgsBuilder.build(state, 11111, osProvider = osProvider)
 
@@ -94,6 +95,7 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         val osProvider = TestOsProvider(isWindows = true)
         state.winShell = WinShell.POWERSHELL_LT_73
         state.mcpConfigInput = mcpWindows
+        state.openFileOnChange = true
 
         val result = CodexArgsBuilder.build(state, 22222, osProvider = osProvider)
 
@@ -128,6 +130,8 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         val osProvider = TestOsProvider(isWindows = true)
         state.winShell = WinShell.POWERSHELL_73_PLUS
         state.mcpConfigInput = mcpWindows
+        state.enableNotification = true
+        state.openFileOnChange = true
 
         val result = CodexArgsBuilder.build(state, 33333, osProvider = osProvider)
 
@@ -165,8 +169,10 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         state.modelReasoningEffort = ModelReasoningEffort.DEFAULT
         state.isPowerShell73OrOver = false
         state.mcpConfigInput = ""
+        state.openFileOnChange = false
+        state.enableNotification = false
 
-        val result = CodexArgsBuilder.build(state, null, osProvider = osProvider)
+        val result = CodexArgsBuilder.build(state, 5555, osProvider = osProvider)
 
         // Verify that only necessary arguments are included
         assertEquals(0, result.size)
@@ -177,6 +183,8 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         val osProvider = TestOsProvider(isWindows = true)
         state.winShell = WinShell.WSL
         state.mcpConfigInput = mcpWindows
+        state.openFileOnChange = true
+        state.enableNotification = true
 
         val result = CodexArgsBuilder.build(state, 44444, osProvider = osProvider)
 


### PR DESCRIPTION
This pull request introduces improvements to notification handling and user feedback in the CodexLauncher plugin. The main changes ensure that notification-related commands are only added when relevant settings are enabled, update the UI to clarify when changes take effect, and expand test coverage for notification scenarios.

**Notification command logic:**
* The `CodexArgsBuilder` now adds the notify command only if either `enableNotification` or `openFileOnChange` is enabled, preventing unnecessary commands when notifications are not needed.

**User interface and feedback:**
* The settings UI now displays a comment under both the "Open file on change" and "Notifications" sections, informing users that changes require a restart to take effect. The "Notifications (Experimental)" label is changed to "Notifications" for clarity. [[1]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R210-R214) [[2]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R227-R229)

**Test coverage improvements:**
* The test suite for `CodexArgsBuilder` is updated to cover cases where notification-related settings are enabled or disabled, ensuring correct command generation for various OS and shell configurations. [[1]](diffhunk://#diff-d5cd658fb3fac93c80ed547e65391cee3ec9d067ef7965696c150d27c7d81f7dR66) [[2]](diffhunk://#diff-d5cd658fb3fac93c80ed547e65391cee3ec9d067ef7965696c150d27c7d81f7dR98) [[3]](diffhunk://#diff-d5cd658fb3fac93c80ed547e65391cee3ec9d067ef7965696c150d27c7d81f7dR133-R134) [[4]](diffhunk://#diff-d5cd658fb3fac93c80ed547e65391cee3ec9d067ef7965696c150d27c7d81f7dR172-R175) [[5]](diffhunk://#diff-d5cd658fb3fac93c80ed547e65391cee3ec9d067ef7965696c150d27c7d81f7dR186-R187)