### PR TITLE
fix: update PowerShell version notation to use '>= 7.3'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -56,7 +56,7 @@ body:
         - zsh
         - bash
         - fish
-        - PowerShell 7.3+
+        - PowerShell (>= 7.3)
         - PowerShell (< 7.3)
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -34,7 +34,7 @@ body:
         - zsh
         - bash
         - fish
-        - PowerShell 7.3+
+        - PowerShell (>= 7.3)
         - PowerShell (< 7.3)
         - Other
   - type: input

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/options/WinShell.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/options/WinShell.kt
@@ -14,7 +14,7 @@ enum class WinShell {
 
     fun toDisplayName(): String = when (this) {
         POWERSHELL_LT_73 -> "PowerShell (< 7.3)"
-        POWERSHELL_73_PLUS -> "PowerShell (7.3+)"
+        POWERSHELL_73_PLUS -> "PowerShell (>= 7.3)"
         WSL -> "WSL"
     }
 }


### PR DESCRIPTION
This pull request standardizes the naming convention for PowerShell versions across both the issue templates and the codebase, improving clarity and consistency for users and developers.

**User-facing improvements:**

* Updated the PowerShell version label in the bug report issue template from "PowerShell 7.3+" to "PowerShell (>= 7.3)" for clearer version specification.
* Updated the PowerShell version label in the question issue template from "PowerShell 7.3+" to "PowerShell (>= 7.3)" for consistency across templates.

**Codebase consistency:**

* Changed the display name for the `POWERSHELL_73_PLUS` enum value in `WinShell.kt` from "PowerShell (7.3+)" to "PowerShell (>= 7.3)" to match the updated templates.