### PR TITLE
feat: file path insertion

### DIFF
--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/actions/LaunchCodexAction.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/actions/LaunchCodexAction.kt
@@ -21,6 +21,10 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
     companion object {
         private const val CODEX_COMMAND = "codex"
         private const val NOTIFICATION_TITLE = "Codex Launcher"
+        private const val DEFAULT_TEXT = "Launch Codex"
+        private const val DEFAULT_DESCRIPTION = "Open a Codex terminal"
+        private const val ACTIVE_TEXT = "Insert File Path"
+        private const val ACTIVE_DESCRIPTION = "Send the current file path to the Codex terminal"
         private val DEFAULT_ICON = IconLoader.getIcon("/icons/codex.svg", LaunchCodexAction::class.java)
         private val ACTIVE_ICON = IconLoader.getIcon("/icons/codex_active.svg", LaunchCodexAction::class.java)
     }
@@ -83,12 +87,22 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
         val project = e.project
         if (project == null) {
             e.presentation.icon = DEFAULT_ICON
+            e.presentation.text = DEFAULT_TEXT
+            e.presentation.description = DEFAULT_DESCRIPTION
             return
         }
 
         val manager = project.service<CodexTerminalManager>()
         val isActive = manager.isCodexTerminalActive()
-        e.presentation.icon = if (isActive) ACTIVE_ICON else DEFAULT_ICON
+        if (isActive) {
+            e.presentation.icon = ACTIVE_ICON
+            e.presentation.text = ACTIVE_TEXT
+            e.presentation.description = ACTIVE_DESCRIPTION
+        } else {
+            e.presentation.icon = DEFAULT_ICON
+            e.presentation.text = DEFAULT_TEXT
+            e.presentation.description = DEFAULT_DESCRIPTION
+        }
     }
 
     private fun buildCommand(args: String): String {

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/actions/LaunchCodexAction.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/actions/LaunchCodexAction.kt
@@ -145,6 +145,7 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
         val lineRange = resolveSelectedLineRange(editorManager)
 
         return buildString {
+            append(' ')
             append(resolvedPath)
             if (lineRange != null) {
                 append(':')
@@ -154,6 +155,7 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
                     append(lineRange.end)
                 }
             }
+            append(' ')
         }
     }
 

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/actions/LaunchCodexAction.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/actions/LaunchCodexAction.kt
@@ -15,15 +15,16 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.IconLoader
 import java.nio.file.Path
+import javax.swing.Icon
 
-class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null), DumbAware {
+class LaunchCodexAction : AnAction(DEFAULT_TEXT, DEFAULT_DESCRIPTION, null), DumbAware {
 
     companion object {
         private const val CODEX_COMMAND = "codex"
         private const val NOTIFICATION_TITLE = "Codex Launcher"
         private const val DEFAULT_TEXT = "Launch Codex"
         private const val DEFAULT_DESCRIPTION = "Open a Codex terminal"
-        private const val ACTIVE_TEXT = "Insert File Path"
+        private const val ACTIVE_TEXT = "Insert File Path into Codex"
         private const val ACTIVE_DESCRIPTION = "Send the current file path to the Codex terminal"
         private val DEFAULT_ICON = IconLoader.getIcon("/icons/codex.svg", LaunchCodexAction::class.java)
         private val ACTIVE_ICON = IconLoader.getIcon("/icons/codex_active.svg", LaunchCodexAction::class.java)
@@ -40,28 +41,43 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
 
         val terminalManager = project.service<CodexTerminalManager>()
         if (terminalManager.isCodexTerminalActive()) {
-            val filePath = resolveSelectedFilePath(project)
-            if (filePath == null) {
-                notify(project, "No active file to send to Codex", NotificationType.INFORMATION)
-                return
-            }
-
-            val sent = terminalManager.typeIntoActiveCodexTerminal(filePath)
-            if (!sent) {
-                notify(project, "Failed to send file path to Codex terminal", NotificationType.WARNING)
-            } else {
-                logger.info("Sent active file path to Codex terminal: $filePath")
-            }
+            performInsert(project, terminalManager)
             return
         }
 
+        launchCodex(project, terminalManager)
+    }
+
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        val state = determineToolbarState(e.project)
+        e.presentation.icon = state.icon
+        e.presentation.text = state.text
+        e.presentation.description = state.description
+    }
+
+    private fun performInsert(project: Project, terminalManager: CodexTerminalManager) {
+        val insertText = resolveInsertText(project)
+        if (insertText == null) {
+            notify(project, "No active file to send to Codex", NotificationType.INFORMATION)
+            return
+        }
+
+        if (!terminalManager.typeIntoActiveCodexTerminal(insertText)) {
+            notify(project, "Failed to send file path to Codex terminal", NotificationType.WARNING)
+            return
+        }
+
+        logger.info("Sent active file path to Codex terminal: $insertText")
+    }
+
+    private fun launchCodex(project: Project, terminalManager: CodexTerminalManager) {
         val baseDir = project.basePath ?: System.getProperty("user.home")
         logger.info("Launching Codex in directory: $baseDir")
 
         try {
             val httpService = ApplicationManager.getApplication().service<HttpTriggerService>()
             val port = httpService.getActualPort()
-
             if (port == 0) {
                 logger.warn("HTTP service port is not available")
                 notify(project, "HTTP service is not properly initialized", NotificationType.WARNING)
@@ -69,39 +85,12 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
             }
 
             val settings = service<CodexLauncherSettings>()
-            val args = settings.getArgs(port)
-            val command = buildCommand(args)
+            val command = buildCommand(settings.getArgs(port))
             terminalManager.launch(baseDir, command)
-
             logger.info("Codex command executed successfully: $command")
-
         } catch (t: Throwable) {
             logger.error("Failed to launch Codex", t)
             notify(project, "Failed to launch Codex: ${t.message}", NotificationType.ERROR)
-        }
-    }
-
-    override fun update(e: AnActionEvent) {
-        super.update(e)
-
-        val project = e.project
-        if (project == null) {
-            e.presentation.icon = DEFAULT_ICON
-            e.presentation.text = DEFAULT_TEXT
-            e.presentation.description = DEFAULT_DESCRIPTION
-            return
-        }
-
-        val manager = project.service<CodexTerminalManager>()
-        val isActive = manager.isCodexTerminalActive()
-        if (isActive) {
-            e.presentation.icon = ACTIVE_ICON
-            e.presentation.text = ACTIVE_TEXT
-            e.presentation.description = ACTIVE_DESCRIPTION
-        } else {
-            e.presentation.icon = DEFAULT_ICON
-            e.presentation.text = DEFAULT_TEXT
-            e.presentation.description = DEFAULT_DESCRIPTION
         }
     }
 
@@ -109,54 +98,55 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
         return buildString {
             append(CODEX_COMMAND)
             if (args.isNotBlank()) {
-                append(" ")
+                append(' ')
                 append(args)
             }
         }
     }
 
     private fun notify(project: Project, content: String, type: NotificationType) {
-        try {
+        runCatching {
             val group = NotificationGroupManager.getInstance().getNotificationGroup("CodexLauncher")
             group.createNotification(NOTIFICATION_TITLE, content, type).notify(project)
-        } catch (e: Exception) {
-            logger.error("Failed to show notification: $content", e)
+        }.onFailure { error ->
+            logger.error("Failed to show notification: $content", error)
         }
     }
 
-    private fun resolveSelectedFilePath(project: Project): String? {
+    private fun resolveInsertText(project: Project): String? {
+        val payload = resolveInsertPayload(project) ?: return null
+        return buildString {
+            append(payload.relativePath)
+            payload.lineRange?.let { range ->
+                append(':')
+                append(range.start)
+                range.end?.takeIf { it != range.start }?.let { end ->
+                    append('-')
+                    append(end)
+                }
+            }
+            append(' ')
+        }
+    }
+
+    private fun resolveInsertPayload(project: Project): InsertPayload? {
         val editorManager = FileEditorManager.getInstance(project)
         val file = editorManager.selectedFiles.firstOrNull() ?: return null
         val rawPath = file.canonicalPath ?: file.presentableUrl ?: file.path
         if (rawPath.isNullOrBlank()) {
             return null
         }
-        val projectBase = project.basePath
-        val resolvedPath = if (!projectBase.isNullOrBlank()) {
+
+        val relativePath = project.basePath?.let { basePath ->
             runCatching {
-                val base = Path.of(projectBase).normalize()
+                val base = Path.of(basePath).normalize()
                 val target = Path.of(rawPath).normalize()
                 if (target.startsWith(base)) base.relativize(target).toString() else rawPath
             }.getOrElse { rawPath }
-        } else {
-            rawPath
-        }
+        } ?: rawPath
 
         val lineRange = resolveSelectedLineRange(editorManager)
-
-        return buildString {
-            append(' ')
-            append(resolvedPath)
-            if (lineRange != null) {
-                append(':')
-                append(lineRange.start)
-                if (lineRange.end != null && lineRange.end != lineRange.start) {
-                    append('-')
-                    append(lineRange.end)
-                }
-            }
-            append(' ')
-        }
+        return InsertPayload(relativePath, lineRange)
     }
 
     private fun resolveSelectedLineRange(editorManager: FileEditorManager): LineRange? {
@@ -165,8 +155,7 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
         if (!selectionModel.hasSelection()) {
             return null
         }
-        val selectedText = selectionModel.selectedText
-        if (selectedText.isNullOrEmpty()) {
+        if (selectionModel.selectedText.isNullOrEmpty()) {
             return null
         }
 
@@ -180,21 +169,40 @@ class LaunchCodexAction : AnAction("Launch Codex", "Open a Codex terminal", null
         if (startLine < 0) {
             return null
         }
+
         val endLine = runCatching {
-            val adjustedEnd = if (endOffset > 0 && endOffset > startOffset && endOffset == document.textLength) endOffset else endOffset - 1
+            val adjustedEnd = when {
+                endOffset <= startOffset -> startOffset
+                endOffset == document.textLength -> endOffset
+                else -> endOffset - 1
+            }
             document.getLineNumber(adjustedEnd.coerceAtLeast(startOffset))
         }.getOrElse {
             logger.warn("Failed to resolve end line number", it)
             startLine
         }
-        if (endLine < 0) {
-            return LineRange(startLine + 1, null)
-        }
 
         val start = startLine + 1
-        val end = endLine + 1
-        return if (end > start) LineRange(start, end) else LineRange(start, null)
+        val end = (endLine + 1).takeIf { it > start }
+        return LineRange(start, end)
     }
 
+    private fun determineToolbarState(project: Project?): ToolbarState {
+        if (project == null) {
+            return ToolbarState(DEFAULT_ICON, DEFAULT_TEXT, DEFAULT_DESCRIPTION)
+        }
+
+        val manager = project.service<CodexTerminalManager>()
+        return if (manager.isCodexTerminalActive()) {
+            ToolbarState(ACTIVE_ICON, ACTIVE_TEXT, ACTIVE_DESCRIPTION)
+        } else {
+            ToolbarState(DEFAULT_ICON, DEFAULT_TEXT, DEFAULT_DESCRIPTION)
+        }
+    }
+
+    private data class InsertPayload(val relativePath: String, val lineRange: LineRange?)
+
     private data class LineRange(val start: Int, val end: Int?)
+
+    private data class ToolbarState(val icon: Icon, val text: String, val description: String)
 }

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/terminal/CodexTerminalManager.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/terminal/CodexTerminalManager.kt
@@ -76,7 +76,7 @@ class CodexTerminalManager(private val project: Project) {
     fun isCodexTerminalActive(): Boolean {
         return try {
             val terminalManager = TerminalToolWindowManager.getInstance(project)
-            getActiveCodexTerminal(terminalManager) != null
+            findDisplayedCodexTerminal(terminalManager) != null
         } catch (t: Throwable) {
             logger.warn("Failed to inspect Codex terminal active state", t)
             false
@@ -86,7 +86,7 @@ class CodexTerminalManager(private val project: Project) {
     fun typeIntoActiveCodexTerminal(text: String): Boolean {
         return try {
             val terminalManager = TerminalToolWindowManager.getInstance(project)
-            val terminal = getActiveCodexTerminal(terminalManager) ?: return false
+            val terminal = findDisplayedCodexTerminal(terminalManager) ?: return false
             typeText(terminal.widget, text)
         } catch (t: Throwable) {
             logger.warn("Failed to type into Codex terminal", t)
@@ -108,7 +108,7 @@ class CodexTerminalManager(private val project: Project) {
         null
     }
 
-    private fun getActiveCodexTerminal(
+    private fun findDisplayedCodexTerminal(
         manager: TerminalToolWindowManager
     ): CodexTerminal? {
         val terminal = locateCodexTerminal(manager) ?: return null

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/terminal/CodexTerminalManager.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/terminal/CodexTerminalManager.kt
@@ -70,6 +70,30 @@ class CodexTerminalManager(private val project: Project) {
         }
     }
 
+    /**
+     * Returns true when the Codex terminal tab is currently selected in the terminal tool window.
+     */
+    fun isCodexTerminalActive(): Boolean {
+        return try {
+            val terminalManager = TerminalToolWindowManager.getInstance(project)
+            getActiveCodexTerminal(terminalManager) != null
+        } catch (t: Throwable) {
+            logger.warn("Failed to inspect Codex terminal active state", t)
+            false
+        }
+    }
+
+    fun typeIntoActiveCodexTerminal(text: String): Boolean {
+        return try {
+            val terminalManager = TerminalToolWindowManager.getInstance(project)
+            val terminal = getActiveCodexTerminal(terminalManager) ?: return false
+            typeText(terminal.widget, text)
+        } catch (t: Throwable) {
+            logger.warn("Failed to type into Codex terminal", t)
+            false
+        }
+    }
+
     private fun locateCodexTerminal(manager: TerminalToolWindowManager): CodexTerminal? = try {
         manager.terminalWidgets.asSequence().mapNotNull { widget ->
             val content = manager.getContainer(widget)?.content ?: return@mapNotNull null
@@ -82,6 +106,21 @@ class CodexTerminalManager(private val project: Project) {
     } catch (t: Throwable) {
         logger.warn("Failed to inspect existing terminal widgets", t)
         null
+    }
+
+    private fun getActiveCodexTerminal(
+        manager: TerminalToolWindowManager
+    ): CodexTerminal? {
+        val terminal = locateCodexTerminal(manager) ?: return null
+        val toolWindow = resolveTerminalToolWindow(manager) ?: return null
+        val selectedContent = toolWindow.contentManager.selectedContent ?: return null
+        if (selectedContent != terminal.content) {
+            return null
+        }
+
+        val toolWindowManager = ToolWindowManager.getInstance(project)
+        val isActive = toolWindow.isVisible && (toolWindow.isActive || toolWindowManager.activeToolWindowId == toolWindow.id)
+        return if (isActive) terminal else null
     }
 
     private fun focusCodexTerminal(
@@ -207,5 +246,45 @@ class CodexTerminalManager(private val project: Project) {
             val method = widget.javaClass.methods.firstOrNull { it.name == "isCommandRunning" && it.parameterCount == 0 }
             method?.apply { isAccessible = true }?.invoke(widget) as? Boolean
         }.getOrNull()
+    }
+
+    private fun typeText(widget: TerminalWidget, text: String): Boolean {
+        val connector = runCatching { widget.ttyConnector }.getOrNull()
+        if (connector != null) {
+            return runCatching {
+                connector.write(text)
+                true
+            }.getOrElse {
+                logger.warn("Failed to write to Codex terminal connector", it)
+                false
+            }
+        }
+
+        val methods = widget.javaClass.methods
+        val typeMethod = methods.firstOrNull { it.name == "typeText" && it.parameterCount == 1 && it.parameterTypes[0] == String::class.java }
+        if (typeMethod != null) {
+            return runCatching {
+                typeMethod.isAccessible = true
+                typeMethod.invoke(widget, text)
+                true
+            }.getOrElse {
+                logger.warn("Failed to invoke typeText on Codex terminal", it)
+                false
+            }
+        }
+
+        val pasteMethod = methods.firstOrNull { it.name == "pasteText" && it.parameterCount == 1 && it.parameterTypes[0] == String::class.java }
+        if (pasteMethod != null) {
+            return runCatching {
+                pasteMethod.isAccessible = true
+                pasteMethod.invoke(widget, text)
+                true
+            }.getOrElse {
+                logger.warn("Failed to invoke pasteText on Codex terminal", it)
+                false
+            }
+        }
+
+        return false
     }
 }

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/terminal/CodexTerminalManager.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/terminal/CodexTerminalManager.kt
@@ -118,9 +118,12 @@ class CodexTerminalManager(private val project: Project) {
             return null
         }
 
-        val toolWindowManager = ToolWindowManager.getInstance(project)
-        val isActive = toolWindow.isVisible && (toolWindow.isActive || toolWindowManager.activeToolWindowId == toolWindow.id)
-        return if (isActive) terminal else null
+        val isDisplayed = toolWindow.isVisible
+        if (!isDisplayed) {
+            return null
+        }
+
+        return terminal
     }
 
     private fun focusCodexTerminal(

--- a/src/main/resources/icons/codex_active.svg
+++ b/src/main/resources/icons/codex_active.svg
@@ -1,6 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Codex Launcher (active)">
   <!-- Active placeholder variant -->
-  <rect x="2" y="3" width="20" height="18" rx="3.2" fill="#2cb491" stroke="#2cb491" stroke-width="1.8" stroke-linejoin="round"></rect>
-  <path d="M11 9.1 A3 3.3 0 1 0 11 15" fill="none" stroke="#FFFFFF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-  <rect x="13.5" y="14.3" width="4" height="1.6" rx="0.6" fill="#FFFFFF" opacity="0.85"></rect>
+  <rect x="2" y="3" width="20" height="18" rx="3.2" fill="#2cb491" stroke="#355a52" stroke-width="1.8" stroke-linejoin="round"></rect>
+  <!-- "./" hint to imply path insertion -->
+  <circle cx="8" cy="16" r="1.2" fill="#eeeeee" opacity="0.94"></circle>
+  <path d="M17 8 L13 16.5" stroke="#eeeeee" stroke-width="1.8" stroke-linecap="round"></path>
 </svg>

--- a/src/main/resources/icons/codex_active.svg
+++ b/src/main/resources/icons/codex_active.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Codex Launcher (active)">
+  <!-- Active placeholder variant -->
+  <rect x="2" y="3" width="20" height="18" rx="3.2" fill="#2cb491" stroke="#2cb491" stroke-width="1.8" stroke-linejoin="round"></rect>
+  <path d="M11 9.1 A3 3.3 0 1 0 11 15" fill="none" stroke="#FFFFFF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+  <rect x="13.5" y="14.3" width="4" height="1.6" rx="0.6" fill="#FFFFFF" opacity="0.85"></rect>
+</svg>


### PR DESCRIPTION
This pull request introduces a new workflow for interacting with the Codex terminal from the IDE toolbar. Now, if the Codex terminal is active, the toolbar button changes to "Insert File Path into Codex" and allows users to send the current file path (and optionally, the selected line range) directly to the terminal. The implementation includes dynamic toolbar state updates, robust file path and line range resolution, and safe text insertion into the terminal. Additionally, new methods have been added to the `CodexTerminalManager` to support these features.

**Toolbar and UI Enhancements:**

* The toolbar button now dynamically updates its icon, text, and description based on whether the Codex terminal is active. When active, it enables sending the current file path and line range to the terminal; otherwise, it launches the Codex terminal. (`LaunchCodexAction.kt`) [[1]](diffhunk://#diff-d8d3eb9556b6b2a575aa3b4f8051481da1b858c3bf663c478ee4e5585ffef102R13-R30) [[2]](diffhunk://#diff-d8d3eb9556b6b2a575aa3b4f8051481da1b858c3bf663c478ee4e5585ffef102R42-L53) [[3]](diffhunk://#diff-d8d3eb9556b6b2a575aa3b4f8051481da1b858c3bf663c478ee4e5585ffef102L64-R208)

**Codex Terminal Interaction:**

* Added logic to detect if the Codex terminal is currently displayed and active, allowing context-sensitive actions from the toolbar. (`CodexTerminalManager.kt`) [[1]](diffhunk://#diff-4ca108b04f2958044f47ee8da1c086b5b8a3f00aa3ae76fd36e9d8162cfcd4ffR73-R96) [[2]](diffhunk://#diff-4ca108b04f2958044f47ee8da1c086b5b8a3f00aa3ae76fd36e9d8162cfcd4ffR111-R128)
* Implemented methods to safely type or paste text into the active Codex terminal, supporting multiple approaches for compatibility. (`CodexTerminalManager.kt`)

**File Path and Line Range Resolution:**

* Added robust resolution of the current file's relative path and selected line range, which is formatted and sent to the Codex terminal when requested. (`LaunchCodexAction.kt`)

These changes make the Codex launcher more interactive and context-aware, streamlining workflows for users who frequently work with the Codex terminal.