### PR TITLE
fix: send command when codex has already exited

### DIFF
--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/terminal/CodexTerminalManager.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/terminal/CodexTerminalManager.kt
@@ -76,7 +76,8 @@ class CodexTerminalManager(private val project: Project) {
     fun isCodexTerminalActive(): Boolean {
         return try {
             val terminalManager = TerminalToolWindowManager.getInstance(project)
-            findDisplayedCodexTerminal(terminalManager) != null
+            val terminal = findDisplayedCodexTerminal(terminalManager) ?: return false
+            isCodexRunning(terminal)
         } catch (t: Throwable) {
             logger.warn("Failed to inspect Codex terminal active state", t)
             false


### PR DESCRIPTION
This pull request updates the logic for checking if the Codex terminal is active. Instead of just verifying the presence of a displayed Codex terminal, the check now also ensures that the Codex process is actually running before reporting the terminal as active.

Terminal activity check improvement:

* Updated `isCodexTerminalActive()` in `CodexTerminalManager.kt` to check both for a displayed Codex terminal and that the Codex process is running, improving accuracy of terminal state detection.