### PR TITLE
Add --search option & UI Improvement

### DIFF
--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilder.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilder.kt
@@ -62,6 +62,10 @@ object CodexArgsBuilder {
             parts += "--full-auto"
         }
 
+        if (state.enableSearch) {
+            parts += "--search"
+        }
+
         // Determine the model name to use
         val modelName: String? = when (state.model) {
             Model.DEFAULT -> null // Use codex default model

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherSettings.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherSettings.kt
@@ -36,6 +36,7 @@ class CodexLauncherSettings : PersistentStateComponent<CodexLauncherSettings.Sta
      * @property customModel Custom model identifier when model is set to CUSTOM
      * @property openFileOnChange Whether to automatically open files when they change
      * @property enableNotification Whether to enable notifications
+     * @property enableSearch Whether to launch Codex CLI with --search flag
      * @property isPowerShell73OrOver Whether using PowerShell 7.3 or later (legacy; use winShell instead)
      * @property winShell Preferred Windows shell selection (Windows only)
      */
@@ -46,6 +47,7 @@ class CodexLauncherSettings : PersistentStateComponent<CodexLauncherSettings.Sta
         var modelReasoningEffort: ModelReasoningEffort = ModelReasoningEffort.DEFAULT,
         var openFileOnChange: Boolean = false,
         var enableNotification: Boolean = false,
+        var enableSearch: Boolean = false,
         var mcpConfigInput: String = "",
         var isPowerShell73OrOver: Boolean = false, // Legacy flag, use winShell instead
         var winShell: WinShell = WinShell.POWERSHELL_LT_73

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/ui/CodexLauncherConfigurable.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/ui/CodexLauncherConfigurable.kt
@@ -48,6 +48,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
     private lateinit var modelReasoningEffortCombo: JComboBox<ModelReasoningEffort>
     private lateinit var openFileOnChangeCheckbox: JBCheckBox
     private lateinit var enableNotificationCheckbox: JBCheckBox
+    private lateinit var enableSearchCheckbox: JBCheckBox
     private lateinit var winShellCombo: JComboBox<WinShell>
     private lateinit var mcpConfigInputArea: JBTextArea
     private lateinit var mcpServerWarningLabel: JBLabel
@@ -97,6 +98,9 @@ class CodexLauncherConfigurable : SearchableConfigurable {
             border = JBUI.Borders.emptyTop(4)
             isVisible = false
         }
+
+        // Search control
+        enableSearchCheckbox = JBCheckBox("Enable web search for Codex CLI (--search)")
 
         // Windows shell selection (Windows only)
         if (SystemInfo.isWindows) {
@@ -200,6 +204,14 @@ class CodexLauncherConfigurable : SearchableConfigurable {
                     cell(modelReasoningEffortCombo)
                 }
             }
+            group("Search") {
+                row {
+                    cell(enableSearchCheckbox)
+                }
+                row {
+                    this.largeComment("Adds the --search flag so Codex can use web results when available.")
+                }
+            }
             group("File Handling") {
                 row {
                     cell(fileHandlingWarningLabel)
@@ -268,6 +280,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
                 getModelReasoningEffort() != s.modelReasoningEffort ||
                 getOpenFileOnChange() != s.openFileOnChange ||
                 getEnableNotification() != s.enableNotification ||
+                getEnableSearch() != s.enableSearch ||
                 (SystemInfo.isWindows && getWinShell() != s.winShell) ||
                 getMcpConfigInput() != s.mcpConfigInput
     }
@@ -286,6 +299,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         s.modelReasoningEffort = getModelReasoningEffort()
         s.openFileOnChange = getOpenFileOnChange()
         s.enableNotification = getEnableNotification()
+        s.enableSearch = getEnableSearch()
         if (SystemInfo.isWindows) {
             s.winShell = getWinShell()
             // update legacy field
@@ -304,6 +318,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         modelReasoningEffortCombo.selectedItem = s.modelReasoningEffort
         openFileOnChangeCheckbox.isSelected = s.openFileOnChange
         enableNotificationCheckbox.isSelected = s.enableNotification
+        enableSearchCheckbox.isSelected = s.enableSearch
         if (SystemInfo.isWindows) {
             winShellCombo.selectedItem = s.winShell
         }
@@ -337,6 +352,10 @@ class CodexLauncherConfigurable : SearchableConfigurable {
 
     private fun getEnableNotification(): Boolean {
         return enableNotificationCheckbox.isSelected
+    }
+
+    private fun getEnableSearch(): Boolean {
+        return enableSearchCheckbox.isSelected
     }
 
     private fun getWinShell(): WinShell {


### PR DESCRIPTION
This pull request updates the Codex Launcher settings UI and backend to add support for a new `--search` flag, and simplifies the mode selection in the configuration panel. The main changes include introducing a checkbox for enabling web search, updating the persistent settings to store this option, and refactoring how the "full auto" mode is selected in the UI.

**Settings and UI Improvements:**

* Added a new `enableSearch` option to `CodexLauncherSettings` to allow users to launch Codex CLI with the `--search` flag. This includes updating the state, documentation, and settings comparison logic. [[1]](diffhunk://#diff-2d35529cc90dbadb654dfeb5941bc31599efe8a8349b66ca44d85eb220872116R39) [[2]](diffhunk://#diff-2d35529cc90dbadb654dfeb5941bc31599efe8a8349b66ca44d85eb220872116R50) [[3]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R274) [[4]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R293) [[5]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22L299-R311)
* Updated the settings UI to replace radio buttons for mode selection with a single checkbox for `--full-auto`, and added a new checkbox for `--search`. The options are now grouped under an "Options" section for clarity. [[1]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22L44-R49) [[2]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22L72-L74) [[3]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R81-R84) [[4]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22L177-L186) [[5]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R195-R205)
* Refactored the logic for determining the selected mode to use the new checkbox instead of radio buttons, simplifying the code.
* Added getter for the new `enableSearch` checkbox and ensured its state is properly loaded and saved. [[1]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R343-R346) [[2]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22L299-R311)

**Backend/CLI Integration:**

* Updated `CodexArgsBuilder` to include the `--search` flag in the CLI arguments when the new setting is enabled.