### PR TITLE
feat: add --cd option for specifying project root directory

### DIFF
--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/actions/LaunchCodexAction.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/actions/LaunchCodexAction.kt
@@ -85,7 +85,7 @@ class LaunchCodexAction : AnAction(DEFAULT_TEXT, DEFAULT_DESCRIPTION, null), Dum
             }
 
             val settings = service<CodexLauncherSettings>()
-            val command = buildCommand(settings.getArgs(port))
+            val command = buildCommand(settings.getArgs(port, baseDir))
             terminalManager.launch(baseDir, command)
             logger.info("Codex command executed successfully: $command")
         } catch (t: Throwable) {

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilder.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilder.kt
@@ -33,6 +33,8 @@ object DefaultOsProvider : OsProvider {
  * This builder translates the plugin's settings into appropriate command-line arguments
  * that can be passed to the codex CLI tool. It handles:
  * - Mode selection (--full-auto flag)
+ * - Optional project search flag (--search)
+ * - Optional working directory selection (--cd)
  * - Model specification (--model parameter)
  * - Custom model handling with proper validation
  * 
@@ -49,13 +51,19 @@ object CodexArgsBuilder {
      * 
      * @param state The current settings state containing user preferences
      * @param port Optional HTTP service port for notify command
+     * @param projectBasePath Optional project base path for --cd handling
      * @return A list of command-line arguments to pass to codex
      * 
      * @example
      * For settings with mode=FULL_AUTO and model=GPT_5:
      * Returns: ["--full-auto", "--model", "gpt-5"]
      */
-    fun build(state: CodexLauncherSettings.State, port: Int? = null, osProvider: OsProvider = DefaultOsProvider): List<String> {
+    fun build(
+        state: CodexLauncherSettings.State,
+        port: Int? = null,
+        osProvider: OsProvider = DefaultOsProvider,
+        projectBasePath: String? = null
+    ): List<String> {
         val parts = mutableListOf<String>()
 
         if (state.mode == Mode.FULL_AUTO) {
@@ -64,6 +72,10 @@ object CodexArgsBuilder {
 
         if (state.enableSearch) {
             parts += "--search"
+        }
+
+        if (state.enableCdProjectRoot && !projectBasePath.isNullOrBlank()) {
+            parts += listOf("--cd", "'${projectBasePath}'")
         }
 
         // Determine the model name to use

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherSettings.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherSettings.kt
@@ -37,6 +37,7 @@ class CodexLauncherSettings : PersistentStateComponent<CodexLauncherSettings.Sta
      * @property openFileOnChange Whether to automatically open files when they change
      * @property enableNotification Whether to enable notifications
      * @property enableSearch Whether to launch Codex CLI with --search flag
+     * @property enableCdProjectRoot Whether to pass the project root via --cd
      * @property isPowerShell73OrOver Whether using PowerShell 7.3 or later (legacy; use winShell instead)
      * @property winShell Preferred Windows shell selection (Windows only)
      */
@@ -48,6 +49,7 @@ class CodexLauncherSettings : PersistentStateComponent<CodexLauncherSettings.Sta
         var openFileOnChange: Boolean = false,
         var enableNotification: Boolean = false,
         var enableSearch: Boolean = false,
+        var enableCdProjectRoot: Boolean = false,
         var mcpConfigInput: String = "",
         var isPowerShell73OrOver: Boolean = false, // Legacy flag, use winShell instead
         var winShell: WinShell = WinShell.POWERSHELL_LT_73
@@ -72,7 +74,9 @@ class CodexLauncherSettings : PersistentStateComponent<CodexLauncherSettings.Sta
      * including notify command configuration.
      * 
      * @param port HTTP service port for notify command
+     * @param projectBasePath Optional project root to pass through --cd
      * @return A space-separated string of command-line arguments
      */
-    fun getArgs(port: Int): String = CodexArgsBuilder.build(state, port).joinToString(" ")
+    fun getArgs(port: Int, projectBasePath: String? = null): String =
+        CodexArgsBuilder.build(state, port, projectBasePath = projectBasePath).joinToString(" ")
 }

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/ui/CodexLauncherConfigurable.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/ui/CodexLauncherConfigurable.kt
@@ -47,6 +47,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
     private lateinit var openFileOnChangeCheckbox: JBCheckBox
     private lateinit var enableNotificationCheckbox: JBCheckBox
     private lateinit var enableSearchCheckbox: JBCheckBox
+    private lateinit var enableCdProjectRootCheckbox: JBCheckBox
     private lateinit var winShellCombo: JComboBox<WinShell>
     private lateinit var mcpConfigInputArea: JBTextArea
     private lateinit var mcpServerWarningLabel: JBLabel
@@ -81,6 +82,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         // Options controls
         modeFullAutoCheckbox = JBCheckBox("--full-auto (Low-friction sandboxed automatic execution)")
         enableSearchCheckbox = JBCheckBox("--search (Enable web search)")
+        enableCdProjectRootCheckbox = JBCheckBox("--cd <project root> (Turn on only when you explicitly need to set the working directory.)")
 
         // File opening control
         openFileOnChangeCheckbox = JBCheckBox("Open files automatically when changed")
@@ -97,9 +99,6 @@ class CodexLauncherConfigurable : SearchableConfigurable {
             border = JBUI.Borders.emptyTop(4)
             isVisible = false
         }
-
-        // Search control
-
         // Windows shell selection (Windows only)
         if (SystemInfo.isWindows) {
             winShellCombo = ComboBox(WinShell.entries.toTypedArray()).apply {
@@ -200,6 +199,9 @@ class CodexLauncherConfigurable : SearchableConfigurable {
                     cell(enableSearchCheckbox)
                 }
                 row {
+                    cell(enableCdProjectRootCheckbox)
+                }
+                row {
                     this.largeComment("For more information, run codex --help")
                 }
             }
@@ -272,6 +274,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
                 getOpenFileOnChange() != s.openFileOnChange ||
                 getEnableNotification() != s.enableNotification ||
                 getEnableSearch() != s.enableSearch ||
+                getEnableCdProjectRoot() != s.enableCdProjectRoot ||
                 (SystemInfo.isWindows && getWinShell() != s.winShell) ||
                 getMcpConfigInput() != s.mcpConfigInput
     }
@@ -291,6 +294,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         s.openFileOnChange = getOpenFileOnChange()
         s.enableNotification = getEnableNotification()
         s.enableSearch = getEnableSearch()
+        s.enableCdProjectRoot = getEnableCdProjectRoot()
         if (SystemInfo.isWindows) {
             s.winShell = getWinShell()
             // update legacy field
@@ -309,6 +313,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         openFileOnChangeCheckbox.isSelected = s.openFileOnChange
         enableNotificationCheckbox.isSelected = s.enableNotification
         enableSearchCheckbox.isSelected = s.enableSearch
+        enableCdProjectRootCheckbox.isSelected = s.enableCdProjectRoot
         if (SystemInfo.isWindows) {
             winShellCombo.selectedItem = s.winShell
         }
@@ -342,6 +347,10 @@ class CodexLauncherConfigurable : SearchableConfigurable {
 
     private fun getEnableSearch(): Boolean {
         return enableSearchCheckbox.isSelected
+    }
+
+    private fun getEnableCdProjectRoot(): Boolean {
+        return enableCdProjectRootCheckbox.isSelected
     }
 
     private fun getWinShell(): WinShell {

--- a/src/test/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilderTest.kt
+++ b/src/test/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilderTest.kt
@@ -178,6 +178,67 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         assertEquals(0, result.size)
     }
 
+    fun testSearchFlagIncludedWhenEnabled() {
+        val osProvider = TestOsProvider(isWindows = false)
+        state.mode = Mode.DEFAULT
+        state.model = Model.DEFAULT
+        state.modelReasoningEffort = ModelReasoningEffort.DEFAULT
+        state.mcpConfigInput = ""
+        state.openFileOnChange = false
+        state.enableNotification = false
+        state.enableSearch = true
+
+        val result = CodexArgsBuilder.build(state, 6000, osProvider = osProvider)
+
+        assertEquals(1, result.size)
+        assertEquals("--search", result.first())
+    }
+
+    fun testCdFlagIncludedWhenEnabled() {
+        val osProvider = TestOsProvider(isWindows = false)
+        state.mode = Mode.DEFAULT
+        state.model = Model.DEFAULT
+        state.modelReasoningEffort = ModelReasoningEffort.DEFAULT
+        state.mcpConfigInput = ""
+        state.openFileOnChange = false
+        state.enableNotification = false
+        state.enableCdProjectRoot = true
+
+        val result = CodexArgsBuilder.build(
+            state,
+            6100,
+            osProvider = osProvider,
+            projectBasePath = "/home/user/project"
+        )
+
+        assertEquals(2, result.size)
+        assertEquals("--cd", result[0])
+        assertEquals("'/home/user/project'", result[1])
+    }
+
+    fun testCdFlagIncludedOnWindows() {
+        val osProvider = TestOsProvider(isWindows = true)
+        state.mode = Mode.DEFAULT
+        state.model = Model.DEFAULT
+        state.modelReasoningEffort = ModelReasoningEffort.DEFAULT
+        state.mcpConfigInput = ""
+        state.openFileOnChange = false
+        state.enableNotification = false
+        state.winShell = WinShell.POWERSHELL_LT_73
+        state.enableCdProjectRoot = true
+
+        val result = CodexArgsBuilder.build(
+            state,
+            6200,
+            osProvider = osProvider,
+            projectBasePath = "C:\\Projects\\Demo"
+        )
+
+        assertEquals(2, result.size)
+        assertEquals("--cd", result[0])
+        assertEquals("'C:\\Projects\\Demo'", result[1])
+    }
+
     fun testComplexArgsFormattingOnWindowsWithWSL() {
         // Test Windows host but WSL selected; should format like non-Windows
         val osProvider = TestOsProvider(isWindows = true)


### PR DESCRIPTION
This pull request introduces a new feature allowing users to optionally pass the project root directory to the Codex CLI tool via a `--cd` flag, controlled through a new setting in the UI. It also updates the command argument builder, settings, and configuration UI to support this feature, and adds tests for the new functionality.

**Feature: Project Root Directory Support**

* Added a new `enableCdProjectRoot` option to `CodexLauncherSettings.State`, allowing users to specify if the project root should be passed to the Codex CLI with the `--cd` flag. (`CodexLauncherSettings.kt`, [[1]](diffhunk://#diff-2d35529cc90dbadb654dfeb5941bc31599efe8a8349b66ca44d85eb220872116R52) [[2]](diffhunk://#diff-2d35529cc90dbadb654dfeb5941bc31599efe8a8349b66ca44d85eb220872116R40)
* Updated `CodexArgsBuilder.build` to accept an optional `projectBasePath` parameter and include `--cd <project root>` in the generated arguments when the new setting is enabled. (`CodexArgsBuilder.kt`, [[1]](diffhunk://#diff-f616095253d386c2ea21d852d4ed7083285cbd1e94b4b2fe7b8bff073f93fc98R54-R66) [[2]](diffhunk://#diff-f616095253d386c2ea21d852d4ed7083285cbd1e94b4b2fe7b8bff073f93fc98R77-R80)
* Modified `CodexLauncherSettings.getArgs` and `LaunchCodexAction` to propagate the project base path when building command-line arguments. (`CodexLauncherSettings.kt`, [[1]](diffhunk://#diff-2d35529cc90dbadb654dfeb5941bc31599efe8a8349b66ca44d85eb220872116R77-R81); `LaunchCodexAction.kt`, [[2]](diffhunk://#diff-d8d3eb9556b6b2a575aa3b4f8051481da1b858c3bf663c478ee4e5585ffef102L88-R88)

**UI Enhancements**

* Added a new checkbox to the settings UI for toggling the `--cd <project root>` option, and ensured its value is saved, loaded, and compared for changes. (`CodexLauncherConfigurable.kt`, [[1]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R50) [[2]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R85) [[3]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R201-R203) [[4]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R277) [[5]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R297) [[6]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R316) [[7]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R352-R355)

**Testing**

* Added unit tests to verify that the `--cd` flag is correctly included in the command-line arguments when enabled, for both Unix and Windows environments. (`CodexArgsBuilderTest.kt`, [src/test/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilderTest.ktR181-R241](diffhunk://#diff-d5cd658fb3fac93c80ed547e65391cee3ec9d067ef7965696c150d27c7d81f7dR181-R241))