### PR TITLE
Refactor test

### DIFF
--- a/src/test/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilderTest.kt
+++ b/src/test/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilderTest.kt
@@ -68,26 +68,24 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         val result = CodexArgsBuilder.build(state, 11111, osProvider = osProvider)
 
         // Verify that complex arguments are properly formatted for non-Windows
-        assertEquals(13, result.size)
-        assertEquals("""--full-auto""", result[0])
-        assertEquals("""--model""", result[1])
-        assertEquals("""'gpt-4o'""", result[2])
-        assertEquals("""-c""", result[3])
-        assertEquals("""'model_reasoning_effort=high'""", result[4])
-        assertEquals("""-c""", result[5])
-        assertEquals("""'notify=["curl", "-s", "-X", "POST", "http://localhost:11111/refresh", "-d"]'""", result[6])
-        assertEquals("""-c""", result[7])
         assertEquals(
-            """'mcp_servers.intellij.command=/Applications/IntelliJ IDEA.app/Contents/jbr/Contents/Home/bin/java'""",
-            result[8]
+            listOf(
+                """--full-auto""",
+                """--model""",
+                """'gpt-4o'""",
+                """-c""",
+                """'model_reasoning_effort=high'""",
+                """-c""",
+                """'notify=["curl", "-s", "-X", "POST", "http://localhost:11111/refresh", "-d"]'""",
+                """-c""",
+                """'mcp_servers.intellij.command=/Applications/IntelliJ IDEA.app/Contents/jbr/Contents/Home/bin/java'""",
+                """-c""",
+                """'mcp_servers.intellij.args=["-classpath", "/Applications/IntelliJ IDEA.app/Contents/plugins/mcpserver/lib/mcpserver-frontend.jar:/Applications/IntelliJ IDEA.app/Contents/lib/util-8.jar", "com.intellij.mcpserver.stdio.McpStdioRunnerKt"]'""",
+                """-c""",
+                """'mcp_servers.intellij.env={"IJ_MCP_SERVER_PORT"="64342"}'"""
+            ),
+            result
         )
-        assertEquals("""-c""", result[9])
-        assertEquals(
-            """'mcp_servers.intellij.args=["-classpath", "/Applications/IntelliJ IDEA.app/Contents/plugins/mcpserver/lib/mcpserver-frontend.jar:/Applications/IntelliJ IDEA.app/Contents/lib/util-8.jar", "com.intellij.mcpserver.stdio.McpStdioRunnerKt"]'""",
-            result[10]
-        )
-        assertEquals("""-c""", result[11])
-        assertEquals("""'mcp_servers.intellij.env={"IJ_MCP_SERVER_PORT"="64342"}'""", result[12])
     }
 
     fun testComplexArgsFormattingOnWindows() {
@@ -100,28 +98,23 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         val result = CodexArgsBuilder.build(state, 22222, osProvider = osProvider)
 
         // Verify that complex arguments are properly formatted for Windows
-        assertEquals(13, result.size)
-        assertEquals("""--full-auto""", result[0])
-        assertEquals("""--model""", result[1])
-        assertEquals("""'gpt-4o'""", result[2])
-        assertEquals("""-c""", result[3])
-        assertEquals("""model_reasoning_effort='high'""", result[4])
-        assertEquals("""-c""", result[5])
-        assertEquals("""notify='[\"curl\", \"-s\", \"-X\", \"POST\", \"http://localhost:22222/refresh\", \"-d\"]'""", result[6])
-        assertEquals("""-c""", result[7])
         assertEquals(
-            """mcp_servers.intellij.command='C:\Program Files\JetBrains\IntelliJ IDEA Community Edition 2025.2.1\jbr\bin\java'""",
-            result[8]
-        )
-        assertEquals("""-c""", result[9])
-        assertEquals(
-            """mcp_servers.intellij.args='[\"-classpath\", \"C:\\Program Files\\JetBrains\\IntelliJ IDEA Community Edition 2025.2.1\\plugins\\mcpserver\\lib\\mcpserver-frontend.jar;C:\\Program Files\\JetBrains\\IntelliJ IDEA Community Edition 2025.2.1\\lib\\util-8.jar\", \"com.intellij.mcpserver.stdio.McpStdioRunnerKt\"]'""",
-            result[10]
-        )
-        assertEquals("""-c""", result[11])
-        assertEquals(
-            """mcp_servers.intellij.env='{\"IJ_MCP_SERVER_PORT\"=\"64342\",\"SystemRoot\"=\"C:\\Windows\"}'""",
-            result[12]
+            listOf(
+                """--full-auto""",
+                """--model""",
+                """'gpt-4o'""",
+                """-c""",
+                """model_reasoning_effort='high'""",
+                """-c""",
+                """notify='[\"curl\", \"-s\", \"-X\", \"POST\", \"http://localhost:22222/refresh\", \"-d\"]'""",
+                """-c""",
+                """mcp_servers.intellij.command='C:\Program Files\JetBrains\IntelliJ IDEA Community Edition 2025.2.1\jbr\bin\java'""",
+                """-c""",
+                """mcp_servers.intellij.args='[\"-classpath\", \"C:\\Program Files\\JetBrains\\IntelliJ IDEA Community Edition 2025.2.1\\plugins\\mcpserver\\lib\\mcpserver-frontend.jar;C:\\Program Files\\JetBrains\\IntelliJ IDEA Community Edition 2025.2.1\\lib\\util-8.jar\", \"com.intellij.mcpserver.stdio.McpStdioRunnerKt\"]'""",
+                """-c""",
+                """mcp_servers.intellij.env='{\"IJ_MCP_SERVER_PORT\"=\"64342\",\"SystemRoot\"=\"C:\\Windows\"}'"""
+            ),
+            result
         )
     }
 
@@ -136,28 +129,23 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         val result = CodexArgsBuilder.build(state, 33333, osProvider = osProvider)
 
         // Verify that complex arguments are properly formatted for Windows with PowerShell 7.3+
-        assertEquals(13, result.size)
-        assertEquals("""--full-auto""", result[0])
-        assertEquals("""--model""", result[1])
-        assertEquals("""'gpt-4o'""", result[2])
-        assertEquals("""-c""", result[3])
-        assertEquals("""model_reasoning_effort='high'""", result[4])
-        assertEquals("""-c""", result[5])
-        assertEquals("""notify='["curl", "-s", "-X", "POST", "http://localhost:33333/refresh", "-d"]'""", result[6])
-        assertEquals("""-c""", result[7])
         assertEquals(
-            """mcp_servers.intellij.command='C:\Program Files\JetBrains\IntelliJ IDEA Community Edition 2025.2.1\jbr\bin\java'""",
-            result[8]
-        )
-        assertEquals("""-c""", result[9])
-        assertEquals(
-            """mcp_servers.intellij.args='["-classpath", "C:\\Program Files\\JetBrains\\IntelliJ IDEA Community Edition 2025.2.1\\plugins\\mcpserver\\lib\\mcpserver-frontend.jar;C:\\Program Files\\JetBrains\\IntelliJ IDEA Community Edition 2025.2.1\\lib\\util-8.jar", "com.intellij.mcpserver.stdio.McpStdioRunnerKt"]'""",
-            result[10]
-        )
-        assertEquals("""-c""", result[11])
-        assertEquals(
-            """mcp_servers.intellij.env='{"IJ_MCP_SERVER_PORT"="64342","SystemRoot"="C:\\Windows"}'""",
-            result[12]
+            listOf(
+                """--full-auto""",
+                """--model""",
+                """'gpt-4o'""",
+                """-c""",
+                """model_reasoning_effort='high'""",
+                """-c""",
+                """notify='["curl", "-s", "-X", "POST", "http://localhost:33333/refresh", "-d"]'""",
+                """-c""",
+                """mcp_servers.intellij.command='C:\Program Files\JetBrains\IntelliJ IDEA Community Edition 2025.2.1\jbr\bin\java'""",
+                """-c""",
+                """mcp_servers.intellij.args='["-classpath", "C:\\Program Files\\JetBrains\\IntelliJ IDEA Community Edition 2025.2.1\\plugins\\mcpserver\\lib\\mcpserver-frontend.jar;C:\\Program Files\\JetBrains\\IntelliJ IDEA Community Edition 2025.2.1\\lib\\util-8.jar", "com.intellij.mcpserver.stdio.McpStdioRunnerKt"]'""",
+                """-c""",
+                """mcp_servers.intellij.env='{"IJ_MCP_SERVER_PORT"="64342","SystemRoot"="C:\\Windows"}'"""
+            ),
+            result
         )
     }
 
@@ -190,8 +178,7 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
 
         val result = CodexArgsBuilder.build(state, 6000, osProvider = osProvider)
 
-        assertEquals(1, result.size)
-        assertEquals("--search", result.first())
+        assertEquals(listOf("--search"), result)
     }
 
     fun testCdFlagIncludedWhenEnabled() {
@@ -211,9 +198,7 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
             projectBasePath = "/home/user/project"
         )
 
-        assertEquals(2, result.size)
-        assertEquals("--cd", result[0])
-        assertEquals("'/home/user/project'", result[1])
+        assertEquals(listOf("--cd", "'/home/user/project'"), result)
     }
 
     fun testCdFlagIncludedOnWindows() {
@@ -234,9 +219,7 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
             projectBasePath = "C:\\Projects\\Demo"
         )
 
-        assertEquals(2, result.size)
-        assertEquals("--cd", result[0])
-        assertEquals("'C:\\Projects\\Demo'", result[1])
+        assertEquals(listOf("--cd", "'C:\\Projects\\Demo'"), result)
     }
 
     fun testComplexArgsFormattingOnWindowsWithWSL() {
@@ -250,11 +233,15 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         val result = CodexArgsBuilder.build(state, 44444, osProvider = osProvider)
 
         // Verify non-Windows style quoting and no SystemRoot
-        assertEquals(5, result.size)
-        assertEquals("""--full-auto""", result[0])
-        assertEquals("""--model""", result[1])
-        assertEquals("""'gpt-4o'""", result[2])
-        assertEquals("""-c""", result[3])
-        assertEquals("""'model_reasoning_effort=high'""", result[4])
+        assertEquals(
+            listOf(
+                """--full-auto""",
+                """--model""",
+                """'gpt-4o'""",
+                """-c""",
+                """'model_reasoning_effort=high'"""
+            ),
+            result
+        )
     }
 }

--- a/src/test/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilderTest.kt
+++ b/src/test/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilderTest.kt
@@ -64,13 +64,23 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         val osProvider = TestOsProvider(isWindows = false)
         state.mcpConfigInput = mcpNonWindows
         state.enableNotification = true
+        state.enableSearch = true
+        state.enableCdProjectRoot = true
 
-        val result = CodexArgsBuilder.build(state, 11111, osProvider = osProvider)
+        val result = CodexArgsBuilder.build(
+            state,
+            11111,
+            osProvider = osProvider,
+            projectBasePath = "/home/user/project"
+        )
 
         // Verify that complex arguments are properly formatted for non-Windows
         assertEquals(
             listOf(
                 """--full-auto""",
+                """--search""",
+                """--cd""",
+                """'/home/user/project'""",
                 """--model""",
                 """'gpt-4o'""",
                 """-c""",
@@ -94,13 +104,23 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         state.winShell = WinShell.POWERSHELL_LT_73
         state.mcpConfigInput = mcpWindows
         state.openFileOnChange = true
+        state.enableSearch = true
+        state.enableCdProjectRoot = true
 
-        val result = CodexArgsBuilder.build(state, 22222, osProvider = osProvider)
+        val result = CodexArgsBuilder.build(
+            state,
+            22222,
+            osProvider = osProvider,
+            projectBasePath = "C:\\Projects\\Demo"
+        )
 
         // Verify that complex arguments are properly formatted for Windows
         assertEquals(
             listOf(
                 """--full-auto""",
+                """--search""",
+                """--cd""",
+                """'C:\Projects\Demo'""",
                 """--model""",
                 """'gpt-4o'""",
                 """-c""",
@@ -125,13 +145,23 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         state.mcpConfigInput = mcpWindows
         state.enableNotification = true
         state.openFileOnChange = true
+        state.enableSearch = true
+        state.enableCdProjectRoot = true
 
-        val result = CodexArgsBuilder.build(state, 33333, osProvider = osProvider)
+        val result = CodexArgsBuilder.build(
+            state,
+            33333,
+            osProvider = osProvider,
+            projectBasePath = "C:\\Projects\\Demo"
+        )
 
         // Verify that complex arguments are properly formatted for Windows with PowerShell 7.3+
         assertEquals(
             listOf(
                 """--full-auto""",
+                """--search""",
+                """--cd""",
+                """'C:\Projects\Demo'""",
                 """--model""",
                 """'gpt-4o'""",
                 """-c""",
@@ -164,62 +194,6 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
 
         // Verify that only necessary arguments are included
         assertEquals(0, result.size)
-    }
-
-    fun testSearchFlagIncludedWhenEnabled() {
-        val osProvider = TestOsProvider(isWindows = false)
-        state.mode = Mode.DEFAULT
-        state.model = Model.DEFAULT
-        state.modelReasoningEffort = ModelReasoningEffort.DEFAULT
-        state.mcpConfigInput = ""
-        state.openFileOnChange = false
-        state.enableNotification = false
-        state.enableSearch = true
-
-        val result = CodexArgsBuilder.build(state, 6000, osProvider = osProvider)
-
-        assertEquals(listOf("--search"), result)
-    }
-
-    fun testCdFlagIncludedWhenEnabled() {
-        val osProvider = TestOsProvider(isWindows = false)
-        state.mode = Mode.DEFAULT
-        state.model = Model.DEFAULT
-        state.modelReasoningEffort = ModelReasoningEffort.DEFAULT
-        state.mcpConfigInput = ""
-        state.openFileOnChange = false
-        state.enableNotification = false
-        state.enableCdProjectRoot = true
-
-        val result = CodexArgsBuilder.build(
-            state,
-            6100,
-            osProvider = osProvider,
-            projectBasePath = "/home/user/project"
-        )
-
-        assertEquals(listOf("--cd", "'/home/user/project'"), result)
-    }
-
-    fun testCdFlagIncludedOnWindows() {
-        val osProvider = TestOsProvider(isWindows = true)
-        state.mode = Mode.DEFAULT
-        state.model = Model.DEFAULT
-        state.modelReasoningEffort = ModelReasoningEffort.DEFAULT
-        state.mcpConfigInput = ""
-        state.openFileOnChange = false
-        state.enableNotification = false
-        state.winShell = WinShell.POWERSHELL_LT_73
-        state.enableCdProjectRoot = true
-
-        val result = CodexArgsBuilder.build(
-            state,
-            6200,
-            osProvider = osProvider,
-            projectBasePath = "C:\\Projects\\Demo"
-        )
-
-        assertEquals(listOf("--cd", "'C:\\Projects\\Demo'"), result)
     }
 
     fun testComplexArgsFormattingOnWindowsWithWSL() {


### PR DESCRIPTION
This pull request updates the `CodexArgsBuilderTest` unit tests to reflect recent changes in how command-line arguments are constructed, especially regarding the inclusion of the `--search` and `--cd` flags and the formatting of argument lists. The changes also remove now-redundant tests that specifically checked for individual flag inclusion, as this is now covered in the more comprehensive argument list assertions.

Key changes include:

**Test coverage updates for new flags and argument formatting:**

- Updated tests (`testComplexArgsFormattingOnNonWindows`, `testComplexArgsFormattingOnWindows`, `testComplexArgsFormattingOnWindowsWithPowerShell73Plus`) to set `enableSearch` and `enableCdProjectRoot` to `true`, and to pass `projectBasePath` to `CodexArgsBuilder.build`. The assertions now check the entire list of arguments, ensuring the new flags and path are included and correctly formatted. [[1]](diffhunk://#diff-d5cd658fb3fac93c80ed547e65391cee3ec9d067ef7965696c150d27c7d81f7dR67-L90) [[2]](diffhunk://#diff-d5cd658fb3fac93c80ed547e65391cee3ec9d067ef7965696c150d27c7d81f7dR107-R137) [[3]](diffhunk://#diff-d5cd658fb3fac93c80ed547e65391cee3ec9d067ef7965696c150d27c7d81f7dR148-R178)
- Changed assertions in these tests from checking individual arguments by index to comparing the entire expected argument list at once. [[1]](diffhunk://#diff-d5cd658fb3fac93c80ed547e65391cee3ec9d067ef7965696c150d27c7d81f7dR67-L90) [[2]](diffhunk://#diff-d5cd658fb3fac93c80ed547e65391cee3ec9d067ef7965696c150d27c7d81f7dR107-R137) [[3]](diffhunk://#diff-d5cd658fb3fac93c80ed547e65391cee3ec9d067ef7965696c150d27c7d81f7dR148-R178) [[4]](diffhunk://#diff-d5cd658fb3fac93c80ed547e65391cee3ec9d067ef7965696c150d27c7d81f7dL253-R219)

**Test cleanup and simplification:**

- Removed redundant tests that only verified the presence of the `--search` and `--cd` flags, as their coverage is now included in the comprehensive argument list assertions.

These updates ensure that the tests accurately reflect the current behavior of the argument builder and reduce duplication in test coverage.