### PR TITLE
fix: disable --cd option when using WSL shell and add warning label

### DIFF
--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilder.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilder.kt
@@ -74,7 +74,11 @@ object CodexArgsBuilder {
             parts += "--search"
         }
 
-        if (state.enableCdProjectRoot && !projectBasePath.isNullOrBlank()) {
+        if (
+            state.enableCdProjectRoot &&
+            !projectBasePath.isNullOrBlank() &&
+            !(osProvider.isWindows && state.winShell == WinShell.WSL)
+        ) {
             parts += listOf("--cd", "'${projectBasePath}'")
         }
 

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/ui/CodexLauncherConfigurable.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/ui/CodexLauncherConfigurable.kt
@@ -48,6 +48,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
     private lateinit var enableNotificationCheckbox: JBCheckBox
     private lateinit var enableSearchCheckbox: JBCheckBox
     private lateinit var enableCdProjectRootCheckbox: JBCheckBox
+    private lateinit var cdProjectRootWarningLabel: JBLabel
     private lateinit var winShellCombo: JComboBox<WinShell>
     private lateinit var mcpConfigInputArea: JBTextArea
     private lateinit var mcpServerWarningLabel: JBLabel
@@ -83,6 +84,11 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         modeFullAutoCheckbox = JBCheckBox("--full-auto (Low-friction sandboxed automatic execution)")
         enableSearchCheckbox = JBCheckBox("--search (Enable web search)")
         enableCdProjectRootCheckbox = JBCheckBox("--cd <project root> (Turn this on only when you explicitly need to set the working directory.)")
+        cdProjectRootWarningLabel = JBLabel("--cd <project root> is unavailable when WSL shell is selected.").apply {
+            foreground = UIUtil.getErrorForeground()
+            border = JBUI.Borders.emptyTop(4)
+            isVisible = false
+        }
 
         // File opening control
         openFileOnChangeCheckbox = JBCheckBox("Open files automatically when changed")
@@ -197,6 +203,9 @@ class CodexLauncherConfigurable : SearchableConfigurable {
                 }
                 row {
                     cell(enableSearchCheckbox)
+                }
+                row {
+                    cell(cdProjectRootWarningLabel)
                 }
                 row {
                     cell(enableCdProjectRootCheckbox)
@@ -365,7 +374,9 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         if (!::mcpConfigInputArea.isInitialized ||
             !::mcpServerWarningLabel.isInitialized ||
             !::fileHandlingWarningLabel.isInitialized ||
-            !::notificationsWarningLabel.isInitialized
+            !::notificationsWarningLabel.isInitialized ||
+            !::enableCdProjectRootCheckbox.isInitialized ||
+            !::cdProjectRootWarningLabel.isInitialized
         ) {
             return
         }
@@ -376,10 +387,12 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         mcpServerWarningLabel.isVisible = isWslSelected
         fileHandlingWarningLabel.isVisible = isWslSelected
         notificationsWarningLabel.isVisible = isWslSelected
+        cdProjectRootWarningLabel.isVisible = isWslSelected
 
         mcpConfigInputArea.isEnabled = !isWslSelected
         openFileOnChangeCheckbox.isEnabled = !isWslSelected
         enableNotificationCheckbox.isEnabled = !isWslSelected
+        enableCdProjectRootCheckbox.isEnabled = !isWslSelected
 
         mcpConfigInputArea.toolTipText = if (isWslSelected) {
             "Integrated MCP Server is unavailable when WSL shell is selected."
@@ -395,6 +408,12 @@ class CodexLauncherConfigurable : SearchableConfigurable {
 
         enableNotificationCheckbox.toolTipText = if (isWslSelected) {
             "Notifications are unavailable when WSL shell is selected."
+        } else {
+            null
+        }
+
+        enableCdProjectRootCheckbox.toolTipText = if (isWslSelected) {
+            "--cd <project root> is unavailable when WSL shell is selected."
         } else {
             null
         }

--- a/src/test/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilderTest.kt
+++ b/src/test/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilderTest.kt
@@ -203,6 +203,7 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         state.mcpConfigInput = mcpWindows
         state.openFileOnChange = true
         state.enableNotification = true
+        state.enableCdProjectRoot = true
 
         val result = CodexArgsBuilder.build(state, 44444, osProvider = osProvider)
 


### PR DESCRIPTION
This pull request improves the handling of the `--cd <project root>` option in both the argument builder and the settings UI, especially for users running under WSL (Windows Subsystem for Linux). The changes ensure that this option is disabled and clearly communicated as unavailable when WSL is selected, preventing misconfiguration and potential errors.

**UI improvements for WSL compatibility:**

* Added a warning label (`cdProjectRootWarningLabel`) to the settings UI, informing users that `--cd <project root>` is unavailable when WSL shell is selected, and made it visible only in that context. The checkbox for enabling this option is also disabled when WSL is selected. [[1]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R51) [[2]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R87-R91) [[3]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R207-R209) [[4]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R390-R395) [[5]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R414-R419)

**Argument building logic:**

* Updated `CodexArgsBuilder` so that the `--cd <project root>` argument is not added when WSL is the selected shell, even if the option is enabled in the settings.

**Test updates:**

* Adjusted tests to ensure that the `enableCdProjectRoot` setting is properly set and tested.