### PR TITLE
feat: add enforcement for author label on issues

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -15,6 +15,7 @@ jobs:
           days-before-issue-stale: 7
           days-before-issue-close: 5
           stale-issue-label: "stale"
+          exempt-issue-labels: "author:x0x0b"
           stale-issue-message: "This issue is stale because it has been open for 7 days with no activity. It will be closed in 5 days if no further activity occurs."
           close-issue-message: "This issue was closed because it has been inactive for 5 days since being marked as stale."
           days-before-pr-stale: -1

--- a/.github/workflows/enforce-author-label.yml
+++ b/.github/workflows/enforce-author-label.yml
@@ -2,7 +2,7 @@ name: Enforce author label
 
 on:
   schedule:
-    - cron: "30 19 * * *"
+    - cron: "45 19 * * *"
   workflow_dispatch:
   issues:
     types: [opened, labeled]

--- a/.github/workflows/enforce-author-label.yml
+++ b/.github/workflows/enforce-author-label.yml
@@ -1,0 +1,125 @@
+name: Enforce author label
+
+on:
+  schedule:
+    - cron: "30 19 * * *"
+  workflow_dispatch:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  enforce:
+    if: github.event_name != 'issues' || github.event.action == 'opened' || (github.event.action == 'labeled' && github.event.label.name == 'author:x0x0b')
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce author label usage
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # ratchet:actions/github-script@v8
+        with:
+          script: |
+            const labelName = 'author:x0x0b';
+            const { owner, repo } = context.repo;
+
+            const ensureLabelExists = async () => {
+              try {
+                await github.rest.issues.getLabel({
+                  owner,
+                  repo,
+                  name: labelName
+                });
+              } catch (error) {
+                if (error.status === 404) {
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name: labelName,
+                    color: 'ededed',
+                    description: 'Issues opened by x0x0b remain active'
+                  });
+                  core.info(`Created label ${labelName}.`);
+                } else {
+                  throw error;
+                }
+              }
+            };
+
+            const addLabel = async (issueNumber) => {
+              await ensureLabelExists();
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                labels: [labelName]
+              });
+              core.info(`Ensured ${labelName} on issue #${issueNumber}.`);
+            };
+
+            const shouldRemoveLabel = (issue) => {
+              if (!issue || issue.pull_request) {
+                return false;
+              }
+              return issue.user?.login !== 'x0x0b';
+            };
+
+            const removeLabel = async (issueNumber) => {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  name: labelName
+                });
+                core.info(`Removed ${labelName} from issue #${issueNumber}.`);
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            };
+
+            if (context.eventName === 'issues') {
+              const issue = context.payload.issue;
+              const action = context.payload.action;
+
+              if (!issue || issue.pull_request) {
+                core.info('Ignoring pull request event.');
+                return;
+              }
+
+              if (action === 'opened') {
+                if (issue.user?.login === 'x0x0b') {
+                  await addLabel(issue.number);
+                } else {
+                  await removeLabel(issue.number);
+                }
+                return;
+              }
+
+              if (action === 'labeled' && shouldRemoveLabel(issue)) {
+                await removeLabel(issue.number);
+              } else {
+                core.info(`No action needed for issue #${issue.number}.`);
+              }
+
+              return;
+            }
+
+            core.info(`Auditing usage of ${labelName}.`);
+
+            const issues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner,
+                repo,
+                labels: labelName,
+                state: 'all',
+                per_page: 100
+              }
+            );
+
+            for (const issue of issues) {
+              if (shouldRemoveLabel(issue)) {
+                await removeLabel(issue.number);
+              }
+            }


### PR DESCRIPTION
This pull request introduces automation to ensure that issues opened by the user `x0x0b` remain active and are not closed as stale. It does this by adding a new workflow to enforce the presence of the `author:x0x0b` label on relevant issues, and by updating the stale issue workflow to exempt issues with this label from being marked as stale or closed.

**Automation for author label enforcement:**

* Added a new workflow (`.github/workflows/enforce-author-label.yml`) that automatically adds the `author:x0x0b` label to issues opened by `x0x0b`, ensures the label exists, and removes it from issues not opened by `x0x0b`. This workflow runs on a schedule and on relevant issue events.

**Updates to stale issue handling:**

* Modified the stale issue workflow (`.github/workflows/close-inactive-issues.yml`) to exempt issues labeled with `author:x0x0b` from being marked as stale or closed due to inactivity.