### PR TITLE
feat: update web search flag to '--enable web_search_request'

### DIFF
--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilder.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilder.kt
@@ -33,7 +33,7 @@ object DefaultOsProvider : OsProvider {
  * This builder translates the plugin's settings into appropriate command-line arguments
  * that can be passed to the codex CLI tool. It handles:
  * - Mode selection (--full-auto flag)
- * - Optional project search flag (--search)
+ * - Optional web search enablement (--enable web_search_request)
  * - Optional working directory selection (--cd)
  * - Model specification (--model parameter)
  * - Custom model handling with proper validation
@@ -71,7 +71,7 @@ object CodexArgsBuilder {
         }
 
         if (state.enableSearch) {
-            parts += "--search"
+            parts += listOf("--enable", "web_search_request")
         }
 
         if (

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherSettings.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherSettings.kt
@@ -36,7 +36,7 @@ class CodexLauncherSettings : PersistentStateComponent<CodexLauncherSettings.Sta
      * @property customModel Custom model identifier when model is set to CUSTOM
      * @property openFileOnChange Whether to automatically open files when they change
      * @property enableNotification Whether to enable notifications
-     * @property enableSearch Whether to launch Codex CLI with --search flag
+     * @property enableSearch Whether to launch Codex CLI with --enable web_search_request flag
      * @property enableCdProjectRoot Whether to pass the project root via --cd
      * @property isPowerShell73OrOver Whether using PowerShell 7.3 or later (legacy; use winShell instead)
      * @property winShell Preferred Windows shell selection (Windows only)

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/ui/CodexLauncherConfigurable.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/ui/CodexLauncherConfigurable.kt
@@ -82,7 +82,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
 
         // Options controls
         modeFullAutoCheckbox = JBCheckBox("--full-auto (Low-friction sandboxed automatic execution)")
-        enableSearchCheckbox = JBCheckBox("--search (Enable web search)")
+        enableSearchCheckbox = JBCheckBox("--enable web_search_request (Enable web search)")
         enableCdProjectRootCheckbox = JBCheckBox("--cd <project root> (Turn this on only when you explicitly need to set the working directory.)")
         cdProjectRootWarningLabel = JBLabel("--cd <project root> is unavailable when WSL shell is selected.").apply {
             foreground = UIUtil.getErrorForeground()

--- a/src/test/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilderTest.kt
+++ b/src/test/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilderTest.kt
@@ -78,7 +78,8 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         assertEquals(
             listOf(
                 """--full-auto""",
-                """--search""",
+                """--enable""",
+                """web_search_request""",
                 """--cd""",
                 """'/home/user/project'""",
                 """--model""",
@@ -118,7 +119,8 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         assertEquals(
             listOf(
                 """--full-auto""",
-                """--search""",
+                """--enable""",
+                """web_search_request""",
                 """--cd""",
                 """'C:\Projects\Demo'""",
                 """--model""",
@@ -159,7 +161,8 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         assertEquals(
             listOf(
                 """--full-auto""",
-                """--search""",
+                """--enable""",
+                """web_search_request""",
                 """--cd""",
                 """'C:\Projects\Demo'""",
                 """--model""",


### PR DESCRIPTION
This pull request updates how the web search feature is enabled when launching the Codex CLI tool. Instead of using the old `--search` flag, the CLI now uses the more explicit `--enable web_search_request` argument. The change is reflected throughout the codebase, including documentation, configuration UI, argument builder logic, and associated tests.

**Web Search Flag Update**

* Updated all documentation and comments to indicate that enabling web search now uses `--enable web_search_request` instead of `--search`. [[1]](diffhunk://#diff-f616095253d386c2ea21d852d4ed7083285cbd1e94b4b2fe7b8bff073f93fc98L36-R36) [[2]](diffhunk://#diff-2d35529cc90dbadb654dfeb5941bc31599efe8a8349b66ca44d85eb220872116L39-R39)
* Changed the argument builder logic in `CodexArgsBuilder` to add `--enable web_search_request` when web search is enabled, replacing the previous `--search` flag.

**Configuration UI**

* Updated the label for the web search option in the settings UI to reflect the new flag (`--enable web_search_request`).

**Tests**

* Updated all relevant tests in `CodexArgsBuilderTest` to expect `--enable web_search_request` instead of `--search`, ensuring proper verification of the new behavior. [[1]](diffhunk://#diff-d5cd658fb3fac93c80ed547e65391cee3ec9d067ef7965696c150d27c7d81f7dL81-R82) [[2]](diffhunk://#diff-d5cd658fb3fac93c80ed547e65391cee3ec9d067ef7965696c150d27c7d81f7dL121-R123) [[3]](diffhunk://#diff-d5cd658fb3fac93c80ed547e65391cee3ec9d067ef7965696c150d27c7d81f7dL162-R165)