### PR TITLE
Update Model enum with new GPT-5.1 variants

### DIFF
--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/options/Model.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/options/Model.kt
@@ -11,15 +11,15 @@ enum class Model {
     /** Do not pass --model. */
     DEFAULT,
 
-    // Legacy / existing models (kept for enterprise compatibility)
-    GPT_5,
-    GPT_5_CODEX,
-    CODEX_MINI_LATEST,
-
     // New gpt-5.1 based models (optional additions)
     GPT_5_1,
     GPT_5_1_CODEX,
     GPT_5_1_CODEX_MINI,
+
+    // Legacy / existing models (kept for enterprise compatibility)
+    GPT_5,
+    GPT_5_CODEX,
+    CODEX_MINI_LATEST,
 
     /** Use customModel from settings. */
     CUSTOM;
@@ -27,15 +27,15 @@ enum class Model {
     fun cliName(): String = when (this) {
         DEFAULT -> ""
 
-        // Existing
-        GPT_5 -> "gpt-5"
-        GPT_5_CODEX -> "gpt-5-codex"
-        CODEX_MINI_LATEST -> "codex-mini-latest"
-
         // New 5.1 models
         GPT_5_1 -> "gpt-5.1"
         GPT_5_1_CODEX -> "gpt-5.1-codex"
         GPT_5_1_CODEX_MINI -> "gpt-5.1-codex-mini"
+
+        // Legacy
+        GPT_5 -> "gpt-5"
+        GPT_5_CODEX -> "gpt-5-codex"
+        CODEX_MINI_LATEST -> "codex-mini-latest"
 
         CUSTOM -> ""
     }
@@ -43,15 +43,15 @@ enum class Model {
     fun toDisplayName(): String = when (this) {
         DEFAULT -> "Default"
 
-        // Existing
-        GPT_5 -> "gpt-5"
-        GPT_5_CODEX -> "gpt-5-codex"
-        CODEX_MINI_LATEST -> "codex-mini-latest"
-
         // New 5.1 models
         GPT_5_1 -> "gpt-5.1"
         GPT_5_1_CODEX -> "gpt-5.1-codex"
         GPT_5_1_CODEX_MINI -> "gpt-5.1-codex-mini"
+
+        // Legacy
+        GPT_5 -> "gpt-5"
+        GPT_5_CODEX -> "gpt-5-codex"
+        CODEX_MINI_LATEST -> "codex-mini-latest"
 
         CUSTOM -> "Custom..."
     }


### PR DESCRIPTION
Models supported in codex 0.58 have been updated to the recently released gpt 5.1 series.