### PR TITLE
feat: add support for custom CLI arguments in Codex configuration

### DIFF
--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilder.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilder.kt
@@ -115,6 +115,11 @@ object CodexArgsBuilder {
             parts += buildMcpConfigArgs(state.mcpConfigInput, osProvider, state.winShell)
         }
 
+        val customArgs = state.customArgs.trim()
+        if (customArgs.isNotEmpty()) {
+            parts += customArgs
+        }
+
         return parts
     }
 

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherSettings.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/CodexLauncherSettings.kt
@@ -38,6 +38,7 @@ class CodexLauncherSettings : PersistentStateComponent<CodexLauncherSettings.Sta
      * @property enableNotification Whether to enable notifications
      * @property enableSearch Whether to launch Codex CLI with --enable web_search_request flag
      * @property enableCdProjectRoot Whether to pass the project root via --cd
+     * @property customArgs Additional CLI arguments appended as-is to the Codex command
      * @property isPowerShell73OrOver Whether using PowerShell 7.3 or later (legacy; use winShell instead)
      * @property winShell Preferred Windows shell selection (Windows only)
      */
@@ -50,6 +51,7 @@ class CodexLauncherSettings : PersistentStateComponent<CodexLauncherSettings.Sta
         var enableNotification: Boolean = false,
         var enableSearch: Boolean = false,
         var enableCdProjectRoot: Boolean = false,
+        var customArgs: String = "",
         var mcpConfigInput: String = "",
         var isPowerShell73OrOver: Boolean = false, // Legacy flag, use winShell instead
         var winShell: WinShell = WinShell.POWERSHELL_LT_73

--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/ui/CodexLauncherConfigurable.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/ui/CodexLauncherConfigurable.kt
@@ -48,6 +48,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
     private lateinit var enableNotificationCheckbox: JBCheckBox
     private lateinit var enableSearchCheckbox: JBCheckBox
     private lateinit var enableCdProjectRootCheckbox: JBCheckBox
+    private lateinit var customArgsField: JBTextField
     private lateinit var cdProjectRootWarningLabel: JBLabel
     private lateinit var winShellCombo: JComboBox<WinShell>
     private lateinit var mcpConfigInputArea: JBTextArea
@@ -88,6 +89,10 @@ class CodexLauncherConfigurable : SearchableConfigurable {
             foreground = UIUtil.getErrorForeground()
             border = JBUI.Borders.emptyTop(4)
             isVisible = false
+        }
+        customArgsField = JBTextField().apply {
+            emptyText.text = "e.g. --foo bar --config '{\"a\":1}'"
+            columns = 50
         }
 
         // File opening control
@@ -213,6 +218,10 @@ class CodexLauncherConfigurable : SearchableConfigurable {
                 row {
                     this.largeComment("For more information, run codex --help")
                 }
+                row("Custom args") {
+                    cell(customArgsField)
+                        .resizableColumn()
+                }
             }
             group("File Handling") {
                 row {
@@ -284,6 +293,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
                 getEnableNotification() != s.enableNotification ||
                 getEnableSearch() != s.enableSearch ||
                 getEnableCdProjectRoot() != s.enableCdProjectRoot ||
+                getCustomArgs() != s.customArgs ||
                 (SystemInfo.isWindows && getWinShell() != s.winShell) ||
                 getMcpConfigInput() != s.mcpConfigInput
     }
@@ -304,6 +314,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         s.enableNotification = getEnableNotification()
         s.enableSearch = getEnableSearch()
         s.enableCdProjectRoot = getEnableCdProjectRoot()
+        s.customArgs = getCustomArgs()
         if (SystemInfo.isWindows) {
             s.winShell = getWinShell()
             // update legacy field
@@ -323,6 +334,7 @@ class CodexLauncherConfigurable : SearchableConfigurable {
         enableNotificationCheckbox.isSelected = s.enableNotification
         enableSearchCheckbox.isSelected = s.enableSearch
         enableCdProjectRootCheckbox.isSelected = s.enableCdProjectRoot
+        customArgsField.text = s.customArgs
         if (SystemInfo.isWindows) {
             winShellCombo.selectedItem = s.winShell
         }
@@ -360,6 +372,10 @@ class CodexLauncherConfigurable : SearchableConfigurable {
 
     private fun getEnableCdProjectRoot(): Boolean {
         return enableCdProjectRootCheckbox.isSelected
+    }
+
+    private fun getCustomArgs(): String {
+        return customArgsField.text?.trim() ?: ""
     }
 
     private fun getWinShell(): WinShell {

--- a/src/test/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilderTest.kt
+++ b/src/test/kotlin/com/github/x0x0b/codexlauncher/cli/CodexArgsBuilderTest.kt
@@ -182,6 +182,28 @@ class CodexArgsBuilderTest : LightPlatformTestCase() {
         )
     }
 
+    fun testCustomArgsAreAppendedAsIs() {
+        val osProvider = TestOsProvider(isWindows = false)
+        state.mode = Mode.FULL_AUTO
+        state.model = Model.CUSTOM
+        state.customModel = "gpt-4o"
+        state.customArgs = """--foo bar --json '{"x":1}'"""
+
+        val result = CodexArgsBuilder.build(state, osProvider = osProvider)
+
+        assertEquals(
+            listOf(
+                """--full-auto""",
+                """--model""",
+                """'gpt-4o'""",
+                """-c""",
+                """'model_reasoning_effort=high'""",
+                """--foo bar --json '{"x":1}'"""
+            ),
+            result
+        )
+    }
+
     fun testMinimalArgs() {
         // Test minimal args on non-Windows
         val osProvider = TestOsProvider(isWindows = false)


### PR DESCRIPTION
This pull request adds support for specifying custom CLI arguments for the Codex launcher. Users can now enter additional arguments in the settings UI, which are appended as-is to the Codex command when launched. The changes include updates to the settings model, UI, argument builder logic, and test coverage.

### Feature: Custom CLI Arguments Support
* Added a new `customArgs` property to `CodexLauncherSettings`, allowing users to specify additional CLI arguments. [[1]](diffhunk://#diff-2d35529cc90dbadb654dfeb5941bc31599efe8a8349b66ca44d85eb220872116R54) [[2]](diffhunk://#diff-2d35529cc90dbadb654dfeb5941bc31599efe8a8349b66ca44d85eb220872116R41)
* Updated the settings UI (`CodexLauncherConfigurable`) to include a text field for custom arguments, with support for saving, loading, and change detection. [[1]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R51) [[2]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R93-R96) [[3]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R221-R224) [[4]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R296) [[5]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R317) [[6]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R337) [[7]](diffhunk://#diff-5e2dd074f355545b788fc0d0bb2bd137c295ddedf222d4cfba6bdf65d6f2af22R377-R380)

### Argument Construction
* Modified `CodexArgsBuilder` to append the custom arguments to the command if provided.

### Testing
* Added a test to verify that custom CLI arguments are correctly appended to the Codex command.