### PR TITLE
feat: add support for GPT-5.2 models

### DIFF
--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/options/Model.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/settings/options/Model.kt
@@ -11,6 +11,9 @@ enum class Model {
     /** Do not pass --model. */
     DEFAULT,
 
+    GPT_5_2_CODEX,
+    GPT_5_2,
+
     // New gpt-5.1 based models (optional additions)
     GPT_5_1,
     GPT_5_1_CODEX,
@@ -28,7 +31,11 @@ enum class Model {
     fun cliName(): String = when (this) {
         DEFAULT -> ""
 
-        // New 5.1 models
+        // 5.2 models
+        GPT_5_2_CODEX -> "gpt-5.2-codex"
+        GPT_5_2 -> "gpt-5.2"
+
+        // 5.1 models
         GPT_5_1 -> "gpt-5.1"
         GPT_5_1_CODEX -> "gpt-5.1-codex"
         GPT_5_1_CODEX_MAX -> "gpt-5.1-codex-max"
@@ -45,7 +52,11 @@ enum class Model {
     fun toDisplayName(): String = when (this) {
         DEFAULT -> "Default"
 
-        // New 5.1 models
+        // 5.2 models
+        GPT_5_2_CODEX -> "gpt-5.2-codex"
+        GPT_5_2 -> "gpt-5.2"
+
+        // 5.1 models
         GPT_5_1 -> "gpt-5.1"
         GPT_5_1_CODEX -> "gpt-5.1-codex"
         GPT_5_1_CODEX_MAX -> "gpt-5.1-codex-max"


### PR DESCRIPTION
This pull request adds support for new GPT-5.2 models to the `Model` enum in the codebase, making them available for selection and use in both the CLI and display interfaces.

Model support additions:

* Added `GPT_5_2_CODEX` and `GPT_5_2` to the `Model` enum in `Model.kt`, enabling support for these new models.

CLI and display integration:

* Updated the `cliName()` method to return the correct CLI argument names for the new GPT-5.2 models.
* Updated the `toDisplayName()` method to provide appropriate display names for the new GPT-5.2 models.