### PR TITLE
fix: avoid RefreshQueue to support IU-242

### DIFF
--- a/src/main/kotlin/com/github/x0x0b/codexlauncher/http/HttpTriggerService.kt
+++ b/src/main/kotlin/com/github/x0x0b/codexlauncher/http/HttpTriggerService.kt
@@ -135,7 +135,11 @@ class HttpTriggerService : Disposable {
                 continue
             }
 
-            VfsUtil.markDirtyAndRefresh(false, true, true, projectRoot)
+            try {
+                VfsUtil.markDirtyAndRefresh(false, true, true, projectRoot)
+            } catch (e: Exception) {
+                logger.warn("VFS refresh failed for ${project.name}: ${e.message}")
+            }
             enqueueProjectProcessing(project, settings, notificationMessage)
         }
     }


### PR DESCRIPTION
avoid following issue

> Class not found (1)
> Access to unresolved class RefreshQueue.Companion (1)

> Field not found (1)
> Access to unresolved field RefreshQueue.Companion (1)
> Method HttpTriggerService.processRefreshRequest(String) contains a getstatic instruction referencing an unresolved field RefreshQueue.Companion. This can lead to NoSuchFieldError exception at runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched from a queued refresh workflow to immediate, direct project filesystem refreshes to improve responsiveness.
* **Bug Fixes**
  * Added fallback error handling and warnings during refresh operations and ensured processing continues promptly after refresh attempts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->