### PR TITLE
fix: increase JVM heap size for IntelliJ plugin build tasks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,5 @@ kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=true
 # Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching=true
+# Allocate enough heap for IntelliJ Platform plugin build and verification tasks.
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build and verification reliability by allocating more memory and enforcing UTF-8 encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->